### PR TITLE
Topic/additional functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,7 @@
 
     emptySTArray :: forall a h r. Eff (st :: ST h | r) (STArray h a)
 
-    getAssocs :: forall a h r. STArray h a -> Eff (st :: ST h | r) [Assoc a]
-
-    getElems :: forall a h r. STArray h a -> Eff (st :: ST h | r) [a]
+    freeze :: forall a h r. STArray h a -> Eff (st :: ST h | r) [a]
 
     peekSTArray :: forall a h r. STArray h a -> Number -> Eff (st :: ST h | r) (Maybe a)
 
@@ -140,6 +138,10 @@
     runSTArray :: forall a r. (forall h. Eff (st :: ST h | r) (STArray h a)) -> Eff r [a]
 
     spliceSTArray :: forall a h r. STArray h a -> Number -> Number -> [a] -> Eff (st :: ST h | r) [a]
+
+    thaw :: forall a h r. [a] -> Eff (st :: ST h | r) (STArray h a)
+
+    toAssocArray :: forall a h r. STArray h a -> Eff (st :: ST h | r) [Assoc a]
 
 
 ## Module Data.Array.Unsafe

--- a/src/Data/Array/ST.purs
+++ b/src/Data/Array/ST.purs
@@ -8,8 +8,8 @@ module Data.Array.ST
   , pushSTArray
   , pushAllSTArray
   , spliceSTArray
-  , getElems
-  , getAssocs
+  , freeze, thaw
+  , toAssocArray
   ) where
 
 import Data.Maybe
@@ -98,8 +98,8 @@ foreign import spliceSTArrayImpl """
 spliceSTArray :: forall a h r. STArray h a -> Number -> Number -> [a] -> Eff (st :: ST h | r) [a]
 spliceSTArray = runFn4 spliceSTArrayImpl
 
-foreign import getElems """
-  function getElems(arr) {
+foreign import copyImpl """
+  function copyImpl(arr) {
     return function(){
       var as = [];
       var i = -1;
@@ -109,10 +109,16 @@ foreign import getElems """
       }
       return as;
     };
-  }""" :: forall a h r. STArray h a -> Eff (st :: ST h | r) [a]
+  }""" :: forall a b h r. a -> Eff (st :: ST h | r) b
 
-foreign import getAssocs """
-  function getAssocs(arr) {
+freeze :: forall a h r. STArray h a -> Eff (st :: ST h | r) [a]
+freeze = copyImpl
+
+thaw :: forall a h r. [a] -> Eff (st :: ST h | r) (STArray h a)
+thaw = copyImpl
+
+foreign import toAssocArray """
+  function toAssocArray(arr) {
     return function(){
       var as = [];
       var i = -1;


### PR DESCRIPTION
I salvaged a few functions from purescript-angular before removing the ST module there. I had been debating sending this PR, but perhaps you might find these useful (as per purescript-contrib/purescript-angular#5).

I also added `getElems` and `getAssocs`. I was on the fence about these, so if you don't think they are needed, I can definitely remove them. Additionally, I've changed the return type of `pushSTArray` to `Number` from `Unit`. I am not sure if this was the right thing to do, but I could go either way.
