### PR TITLE
make `head` and `last` O(1), not O(n).

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,160 +2,498 @@
 
 ## Module Data.Array
 
-### Type Class Instances
+#### `(!!)`
 
-    instance altArray :: Alt Prim.Array
-
-    instance alternativeArray :: Alternative Prim.Array
-
-    instance applicativeArray :: Applicative Prim.Array
-
-    instance applyArray :: Apply Prim.Array
-
-    instance bindArray :: Bind Prim.Array
-
-    instance functorArray :: Functor Prim.Array
-
-    instance monadArray :: Monad Prim.Array
-
-    instance monadPlusArray :: MonadPlus Prim.Array
-
-    instance plusArray :: Plus Prim.Array
-
-    instance semigroupArray :: Semigroup [a]
+``` purescript
+(!!) :: forall a. [a] -> Number -> Maybe a
+```
 
 
-### Values
+#### `snoc`
 
-    (!!) :: forall a. [a] -> Number -> Maybe a
+``` purescript
+snoc :: forall a. [a] -> a -> [a]
+```
 
-    (..) :: Number -> Number -> [Number]
 
-    (\\) :: forall a. (Eq a) => [a] -> [a] -> [a]
+#### `singleton`
 
-    append :: forall a. [a] -> [a] -> [a]
+``` purescript
+singleton :: forall a. a -> [a]
+```
 
-    catMaybes :: forall a. [Maybe a] -> [a]
 
-    concat :: forall a. [[a]] -> [a]
+#### `head`
 
-    concatMap :: forall a b. (a -> [b]) -> [a] -> [b]
+``` purescript
+head :: forall a. [a] -> Maybe a
+```
 
-    delete :: forall a. (Eq a) => a -> [a] -> [a]
 
-    deleteAt :: forall a. Number -> Number -> [a] -> [a]
+#### `last`
 
-    deleteBy :: forall a. (a -> a -> Boolean) -> a -> [a] -> [a]
+``` purescript
+last :: forall a. [a] -> Maybe a
+```
 
-    drop :: forall a. Number -> [a] -> [a]
 
-    dropWhile :: forall a. (a -> Boolean) -> [a] -> [a]
+#### `tail`
 
-    elemIndex :: forall a. (Eq a) => a -> [a] -> Number
+``` purescript
+tail :: forall a. [a] -> Maybe [a]
+```
 
-    elemLastIndex :: forall a. (Eq a) => a -> [a] -> Number
 
-    filter :: forall a. (a -> Boolean) -> [a] -> [a]
+#### `init`
 
-    findIndex :: forall a. (a -> Boolean) -> [a] -> Number
+``` purescript
+init :: forall a. [a] -> Maybe [a]
+```
 
-    findLastIndex :: forall a. (a -> Boolean) -> [a] -> Number
 
-    group :: forall a. (Eq a) => [a] -> [[a]]
+#### `null`
 
-    group' :: forall a. (Ord a) => [a] -> [[a]]
+``` purescript
+null :: forall a. [a] -> Boolean
+```
 
-    groupBy :: forall a. (a -> a -> Boolean) -> [a] -> [[a]]
 
-    head :: forall a. [a] -> Maybe a
+#### `length`
 
-    init :: forall a. [a] -> Maybe [a]
+``` purescript
+length :: forall a. [a] -> Number
+```
 
-    insertAt :: forall a. Number -> a -> [a] -> [a]
 
-    intersect :: forall a. (Eq a) => [a] -> [a] -> [a]
+#### `findIndex`
 
-    intersectBy :: forall a. (a -> a -> Boolean) -> [a] -> [a] -> [a]
+``` purescript
+findIndex :: forall a. (a -> Boolean) -> [a] -> Number
+```
 
-    last :: forall a. [a] -> Maybe a
 
-    length :: forall a. [a] -> Number
+#### `findLastIndex`
 
-    map :: forall a b. (a -> b) -> [a] -> [b]
+``` purescript
+findLastIndex :: forall a. (a -> Boolean) -> [a] -> Number
+```
 
-    mapMaybe :: forall a b. (a -> Maybe b) -> [a] -> [b]
 
-    nub :: forall a. (Eq a) => [a] -> [a]
+#### `elemIndex`
 
-    nubBy :: forall a. (a -> a -> Boolean) -> [a] -> [a]
+``` purescript
+elemIndex :: forall a. (Eq a) => a -> [a] -> Number
+```
 
-    null :: forall a. [a] -> Boolean
 
-    range :: Number -> Number -> [Number]
+#### `elemLastIndex`
 
-    reverse :: forall a. [a] -> [a]
+``` purescript
+elemLastIndex :: forall a. (Eq a) => a -> [a] -> Number
+```
 
-    singleton :: forall a. a -> [a]
 
-    snoc :: forall a. [a] -> a -> [a]
+#### `append`
 
-    sort :: forall a. (Ord a) => [a] -> [a]
+``` purescript
+append :: forall a. [a] -> [a] -> [a]
+```
 
-    sortBy :: forall a. (a -> a -> Ordering) -> [a] -> [a]
 
-    span :: forall a. (a -> Boolean) -> [a] -> { rest :: [a], init :: [a] }
+#### `concat`
 
-    tail :: forall a. [a] -> Maybe [a]
+``` purescript
+concat :: forall a. [[a]] -> [a]
+```
 
-    take :: forall a. Number -> [a] -> [a]
 
-    takeWhile :: forall a. (a -> Boolean) -> [a] -> [a]
+#### `reverse`
 
-    updateAt :: forall a. Number -> a -> [a] -> [a]
+``` purescript
+reverse :: forall a. [a] -> [a]
+```
 
-    zipWith :: forall a b c. (a -> b -> c) -> [a] -> [b] -> [c]
+
+#### `drop`
+
+``` purescript
+drop :: forall a. Number -> [a] -> [a]
+```
+
+
+#### `take`
+
+``` purescript
+take :: forall a. Number -> [a] -> [a]
+```
+
+
+#### `insertAt`
+
+``` purescript
+insertAt :: forall a. Number -> a -> [a] -> [a]
+```
+
+
+#### `deleteAt`
+
+``` purescript
+deleteAt :: forall a. Number -> Number -> [a] -> [a]
+```
+
+
+#### `updateAt`
+
+``` purescript
+updateAt :: forall a. Number -> a -> [a] -> [a]
+```
+
+
+#### `deleteBy`
+
+``` purescript
+deleteBy :: forall a. (a -> a -> Boolean) -> a -> [a] -> [a]
+```
+
+
+#### `delete`
+
+``` purescript
+delete :: forall a. (Eq a) => a -> [a] -> [a]
+```
+
+
+#### `(\\)`
+
+``` purescript
+(\\) :: forall a. (Eq a) => [a] -> [a] -> [a]
+```
+
+
+#### `intersectBy`
+
+``` purescript
+intersectBy :: forall a. (a -> a -> Boolean) -> [a] -> [a] -> [a]
+```
+
+
+#### `intersect`
+
+``` purescript
+intersect :: forall a. (Eq a) => [a] -> [a] -> [a]
+```
+
+
+#### `concatMap`
+
+``` purescript
+concatMap :: forall a b. (a -> [b]) -> [a] -> [b]
+```
+
+
+#### `map`
+
+``` purescript
+map :: forall a b. (a -> b) -> [a] -> [b]
+```
+
+
+#### `mapMaybe`
+
+``` purescript
+mapMaybe :: forall a b. (a -> Maybe b) -> [a] -> [b]
+```
+
+
+#### `catMaybes`
+
+``` purescript
+catMaybes :: forall a. [Maybe a] -> [a]
+```
+
+
+#### `filter`
+
+``` purescript
+filter :: forall a. (a -> Boolean) -> [a] -> [a]
+```
+
+
+#### `range`
+
+``` purescript
+range :: Number -> Number -> [Number]
+```
+
+
+#### `(..)`
+
+``` purescript
+(..) :: Number -> Number -> [Number]
+```
+
+
+#### `zipWith`
+
+``` purescript
+zipWith :: forall a b c. (a -> b -> c) -> [a] -> [b] -> [c]
+```
+
+
+#### `nub`
+
+``` purescript
+nub :: forall a. (Eq a) => [a] -> [a]
+```
+
+
+#### `nubBy`
+
+``` purescript
+nubBy :: forall a. (a -> a -> Boolean) -> [a] -> [a]
+```
+
+
+#### `sort`
+
+``` purescript
+sort :: forall a. (Ord a) => [a] -> [a]
+```
+
+
+#### `sortBy`
+
+``` purescript
+sortBy :: forall a. (a -> a -> Ordering) -> [a] -> [a]
+```
+
+
+#### `group`
+
+``` purescript
+group :: forall a. (Eq a) => [a] -> [[a]]
+```
+
+
+#### `group'`
+
+``` purescript
+group' :: forall a. (Ord a) => [a] -> [[a]]
+```
+
+Performs a sorting first.
+
+#### `groupBy`
+
+``` purescript
+groupBy :: forall a. (a -> a -> Boolean) -> [a] -> [[a]]
+```
+
+
+#### `span`
+
+``` purescript
+span :: forall a. (a -> Boolean) -> [a] -> { rest :: [a], init :: [a] }
+```
+
+
+#### `takeWhile`
+
+``` purescript
+takeWhile :: forall a. (a -> Boolean) -> [a] -> [a]
+```
+
+
+#### `dropWhile`
+
+``` purescript
+dropWhile :: forall a. (a -> Boolean) -> [a] -> [a]
+```
+
+
+#### `functorArray`
+
+``` purescript
+instance functorArray :: Functor Prim.Array
+```
+
+
+#### `applyArray`
+
+``` purescript
+instance applyArray :: Apply Prim.Array
+```
+
+
+#### `applicativeArray`
+
+``` purescript
+instance applicativeArray :: Applicative Prim.Array
+```
+
+
+#### `bindArray`
+
+``` purescript
+instance bindArray :: Bind Prim.Array
+```
+
+
+#### `monadArray`
+
+``` purescript
+instance monadArray :: Monad Prim.Array
+```
+
+
+#### `semigroupArray`
+
+``` purescript
+instance semigroupArray :: Semigroup [a]
+```
+
+
+#### `altArray`
+
+``` purescript
+instance altArray :: Alt Prim.Array
+```
+
+
+#### `plusArray`
+
+``` purescript
+instance plusArray :: Plus Prim.Array
+```
+
+
+#### `alternativeArray`
+
+``` purescript
+instance alternativeArray :: Alternative Prim.Array
+```
+
+
+#### `monadPlusArray`
+
+``` purescript
+instance monadPlusArray :: MonadPlus Prim.Array
+```
+
 
 
 ## Module Data.Array.ST
 
-### Types
+#### `STArray`
 
-    type Assoc a = { index :: Number, value :: a }
+``` purescript
+data STArray :: * -> * -> *
+```
 
-    data STArray :: * -> * -> *
+
+#### `Assoc`
+
+``` purescript
+type Assoc a = { index :: Number, value :: a }
+```
 
 
-### Values
+#### `runSTArray`
 
-    emptySTArray :: forall a h r. Eff (st :: ST h | r) (STArray h a)
+``` purescript
+runSTArray :: forall a r. (forall h. Eff (st :: ST h | r) (STArray h a)) -> Eff r [a]
+```
 
-    freeze :: forall a h r. STArray h a -> Eff (st :: ST h | r) [a]
 
-    peekSTArray :: forall a h r. STArray h a -> Number -> Eff (st :: ST h | r) (Maybe a)
+#### `emptySTArray`
 
-    pokeSTArray :: forall a h r. STArray h a -> Number -> a -> Eff (st :: ST h | r) Boolean
+``` purescript
+emptySTArray :: forall a h r. Eff (st :: ST h | r) (STArray h a)
+```
 
-    pushAllSTArray :: forall a h r. STArray h a -> [a] -> Eff (st :: ST h | r) Number
 
-    pushSTArray :: forall a h r. STArray h a -> a -> Eff (st :: ST h | r) Number
+#### `peekSTArray`
 
-    runSTArray :: forall a r. (forall h. Eff (st :: ST h | r) (STArray h a)) -> Eff r [a]
+``` purescript
+peekSTArray :: forall a h r. STArray h a -> Number -> Eff (st :: ST h | r) (Maybe a)
+```
 
-    spliceSTArray :: forall a h r. STArray h a -> Number -> Number -> [a] -> Eff (st :: ST h | r) [a]
 
-    thaw :: forall a h r. [a] -> Eff (st :: ST h | r) (STArray h a)
+#### `pokeSTArray`
 
-    toAssocArray :: forall a h r. STArray h a -> Eff (st :: ST h | r) [Assoc a]
+``` purescript
+pokeSTArray :: forall a h r. STArray h a -> Number -> a -> Eff (st :: ST h | r) Boolean
+```
+
+
+#### `pushAllSTArray`
+
+``` purescript
+pushAllSTArray :: forall a h r. STArray h a -> [a] -> Eff (st :: ST h | r) Number
+```
+
+
+#### `pushSTArray`
+
+``` purescript
+pushSTArray :: forall a h r. STArray h a -> a -> Eff (st :: ST h | r) Number
+```
+
+
+#### `spliceSTArray`
+
+``` purescript
+spliceSTArray :: forall a h r. STArray h a -> Number -> Number -> [a] -> Eff (st :: ST h | r) [a]
+```
+
+
+#### `freeze`
+
+``` purescript
+freeze :: forall a h r. STArray h a -> Eff (st :: ST h | r) [a]
+```
+
+
+#### `thaw`
+
+``` purescript
+thaw :: forall a h r. [a] -> Eff (st :: ST h | r) (STArray h a)
+```
+
+
+#### `toAssocArray`
+
+``` purescript
+toAssocArray :: forall a h r. STArray h a -> Eff (st :: ST h | r) [Assoc a]
+```
+
 
 
 ## Module Data.Array.Unsafe
 
-### Values
+#### `head`
 
-    head :: forall a. [a] -> a
+``` purescript
+head :: forall a. [a] -> a
+```
 
-    init :: forall a. [a] -> [a]
 
-    last :: forall a. [a] -> a
+#### `tail`
 
-    tail :: forall a. [a] -> [a]
+``` purescript
+tail :: forall a. [a] -> [a]
+```
+
+
+#### `last`
+
+``` purescript
+last :: forall a. [a] -> a
+```
+
+
+#### `init`
+
+``` purescript
+init :: forall a. [a] -> [a]
+```

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -75,13 +75,10 @@ singleton :: forall a. a -> [a]
 singleton a = [a]
 
 head :: forall a. [a] -> Maybe a
-head (x : _) = Just x
-head _       = Nothing
+head xs = xs !! 0
 
 last :: forall a. [a] -> Maybe a
-last (x : []) = Just x
-last (_ : xs) = last xs
-last _        = Nothing
+last xs = xs !! (length xs - 1)
 
 tail :: forall a. [a] -> Maybe [a]
 tail (_ : xs) = Just xs

--- a/src/Data/Array/Unsafe.purs
+++ b/src/Data/Array/Unsafe.purs
@@ -5,7 +5,7 @@ import Data.Maybe.Unsafe
 import qualified Data.Array as A
 
 head :: forall a. [a] -> a
-head (x : _) = x
+head xs = unsafeIndex xs 0
 
 tail :: forall a. [a] -> [a]
 tail (_ : xs) = xs


### PR DESCRIPTION
refs #13.

Avoid pattern matching for `head` and `last` to make them O(1).

Note that this changes behaviour slightly - `Data.Array.Unsafe.head ([] :: [Unit]) == unit`, because it now uses `unsafeIndex`. Previously it would throw "Failed pattern match".