### PR TITLE
Resolving RangeError for concat

### DIFF
--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -205,7 +205,9 @@ foreign import concat
   function concat (xss) {
     var result = [];
     for (var i = 0, l = xss.length; i < l; i++) {
-      result.push.apply(result, xss[i]);
+      for (var j = 0, m = xss[i].length; j < m; j++) {
+        result.push(xss[i][j]);
+      }
     }
     return result;
   }


### PR DESCRIPTION
Refactors the concat implementation to avoid the apply function due to a
RangeError for large arrays.

Resolves purescript/purescript-arrays#41