### PR TITLE
Add fromFoldable

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,7 +7,6 @@
   "futurehostile": true,
   "strict": "global",
   "latedef": true,
-  "maxparams": 1,
   "noarg": true,
   "nocomma": true,
   "nonew": true,

--- a/src/Data/Array.js
+++ b/src/Data/Array.js
@@ -43,8 +43,9 @@ exports.fromFoldableImpl = (function () {
 
   function listToArray (list) {
     var result = [];
+    var count = 0;
     while (list !== emptyList) {
-      result.push(list.head);
+      result[count++] = list.head;
       list = list.tail;
     }
     return result;

--- a/src/Data/Array.js
+++ b/src/Data/Array.js
@@ -28,6 +28,35 @@ exports.replicate = function (n) {
   };
 };
 
+exports.fromFoldableImpl = (function () {
+  function Cons (head, tail) {
+    this.head = head;
+    this.tail = tail;
+  }
+  var emptyList = {};
+
+  function curryCons (head) {
+    return function (tail) {
+      return new Cons(head, tail);
+    };
+  }
+
+  function listToArray (list) {
+    var result = [];
+    while (list !== emptyList) {
+      result.push(list.head);
+      list = list.tail;
+    }
+    return result;
+  }
+
+  return function (foldr) {
+    return function (xs) {
+      return listToArray(foldr(curryCons)(emptyList)(xs));
+    };
+  };
+})();
+
 //------------------------------------------------------------------------------
 // Array size ------------------------------------------------------------------
 //------------------------------------------------------------------------------
@@ -195,7 +224,6 @@ exports.partition = function (f) {
 
 exports.sortImpl = function (f) {
   return function (l) {
-    /* jshint maxparams: 2 */
     return l.slice().sort(function (x, y) {
       return f(x)(y);
     });

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -34,6 +34,7 @@ module Data.Array
   , replicateM
   , some
   , many
+  , fromFoldable
 
   , null
   , length
@@ -107,7 +108,7 @@ import Control.Alt ((<|>))
 import Control.Alternative (class Alternative)
 import Control.Lazy (class Lazy, defer)
 
-import Data.Foldable (foldl)
+import Data.Foldable (class Foldable, foldl, foldr)
 import Data.Maybe (Maybe(..), maybe, isJust, fromJust)
 import Data.Traversable (sequence)
 import Data.Tuple (Tuple(..))
@@ -147,6 +148,12 @@ some v = (:) <$> v <*> defer (\_ -> many v)
 -- | termination.
 many :: forall f a. (Alternative f, Lazy (f (Array a))) => f a -> f (Array a)
 many v = some v <|> pure []
+
+-- | Construct an `Array` from any `Foldable` structure.
+fromFoldable :: forall f a. (Foldable f) => f a -> Array a
+fromFoldable = fromFoldableImpl foldr
+
+foreign import fromFoldableImpl :: forall f a. (forall b. (a -> b -> b) -> b -> f a -> b) -> f a -> Array a
 
 --------------------------------------------------------------------------------
 -- Array size ------------------------------------------------------------------


### PR DESCRIPTION
Refs #53. This implementation seems to work, but is not stack-safe (on my machine, on node.js, it fails with >= 5658 elements). Could `arrays` add a `tailrec` dependency, maybe?