### PR TITLE
Treat negative arguments as zero, fixes #25

### DIFF
--- a/src/Data/Array.js
+++ b/src/Data/Array.js
@@ -243,6 +243,12 @@ exports.slice = function (s) {
   };
 };
 
+exports.take = function (n) {
+  return function (l) {
+    return n < 1 ? [] : l.slice(0, n);
+  };
+};
+
 exports.drop = function (n) {
   return function (l) {
     return n < 1 ? l : l.slice(n);

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -441,8 +441,7 @@ foreign import slice :: forall a. Int -> Int -> Array a -> Array a
 
 -- | Keep only a number of elements from the start of an array, creating a new
 -- | array.
-take :: forall a. Int -> Array a -> Array a
-take = slice 0
+foreign import take :: forall a. Int -> Array a -> Array a
 
 -- | Calculate the longest initial subarray for which all element satisfy the
 -- | specified predicate, creating a new array.

--- a/test/Test/Data/Array.purs
+++ b/test/Test/Data/Array.purs
@@ -233,6 +233,10 @@ testArray = do
   assert $ (dropWhile (_ /= 2) [1, 2, 3]) == [2, 3]
   assert $ (dropWhile (_ /= 1) nil) == nil
 
+  log "take and drop should treat negative arguments as zero"
+  assert $ (take (-2) [1, 2, 3]) == nil
+  assert $ (drop (-2) [1, 2, 3]) == [1, 2, 3]
+
   log "span should split an array in two based on a predicate"
   let spanResult = span (_ < 4) [1, 2, 3, 4, 5, 6, 7]
   assert $ spanResult.init == [1, 2, 3]


### PR DESCRIPTION
This PR changes the behavior of `take` for negative arguments to be consistent with that of `drop` (same behavior as in Haskell).
``` purs
take (-2) [1, 2, 3]) == []
```

This is similar to the fix in PR #26, which is outdated.