### PR TITLE
Add filterA, a faster version of filterM

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "purescript-assert": "^2.0.0",
-    "purescript-console": "^2.0.0"
+    "purescript-console": "^2.0.0",
+    "purescript-const": "^2.0.0"
   }
 }

--- a/test/Test/Data/Array.purs
+++ b/test/Test/Data/Array.purs
@@ -5,6 +5,7 @@ import Prelude
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (log, CONSOLE)
 
+import Data.Const (Const(..))
 import Data.Array as A
 import Data.Array ((:), (\\), (!!))
 import Data.Foldable (for_, foldMapDefaultR, class Foldable, all, traverse_)
@@ -205,9 +206,12 @@ testArray = do
   log "filter should remove items that don't match a predicate"
   assert $ A.filter odd (A.range 0 10) == [1, 3, 5, 7, 9]
 
-  log "filterM should remove items that don't match a predicate while using a monadic behaviour"
-  assert $ A.filterM (Just <<< odd) (A.range 0 10) == Just [1, 3, 5, 7, 9]
-  assert $ A.filterM (const Nothing) (A.range 0 10) == Nothing
+  log "filterA should remove items that don't match a predicate while using an applicative behaviour"
+  assert $ A.filterA (Just <<< odd) (A.range 0 10) == Just [1, 3, 5, 7, 9]
+  assert $ A.filterA (const Nothing) (A.range 0 10) == Nothing
+
+  log "filterA should apply effects in the right order"
+  assert $ A.filterA (Const <<< show) (A.range 1 5) == Const "12345"
 
   log "mapMaybe should transform every item in an array, throwing out Nothing values"
   assert $ A.mapMaybe (\x -> if x /= 0 then Just x else Nothing) [0, 1, 0, 0, 2, 3] == [1, 2, 3]


### PR DESCRIPTION
Change filterM to just be filterA in order to have this be a non-breaking change; I was just thinking it would be nice for all these performance improvements to be available for people without having to update to the next major version.

This removes another use of uncons, refs #71.

The new devDependency on `Const` is because that seemed like the best choice for testing that effects are applied in the right order; the tests were not previously testing that `filterM` applies effects in the right order.

Benchmarking code:

```purescript
benchFilterM :: Benchmark
benchFilterM = mkBenchmark
  { slug: "filterM"
  , title: "filterM"
  , sizes: A.range 1 5 <#> (_ * 500)
  , sizeInterpretation: "Length of the array"
  , inputsPerSize: 1
  , gen: \n -> vectorOf n (arbitrary :: Gen Int)
  , functions: [ benchFn "current"   (currentFilterM pred)
               , benchFn "suggested" (suggestedFilterM pred)
               ]
  }
  where
  pred :: Int -> WriterT Unit Identity Boolean
  pred x = tell unit $> even x
```

I had to stop at 2500 elements since the current implementation stack overflows at around 3k, but the new implementation should work for much larger arrays, because of the stack-safety of the `Traversable Array` instance. I tested this implementation with up to 10k elements and it seemed to work fine.