### PR TITLE
Faster concat.

### DIFF
--- a/src/Data/Array.js
+++ b/src/Data/Array.js
@@ -188,6 +188,12 @@ exports.reverse = function (l) {
 };
 
 exports.concat = function (xss) {
+  if (xss.length <= 10000) {
+    // This method is faster, but it crashes on big arrays.
+    // So we use it when can and fallback to simple variant otherwise.
+    return Array.prototype.concat.apply([], xss);
+  }
+
   var result = [];
   for (var i = 0, l = xss.length; i < l; i++) {
     var xs = xss[i];


### PR DESCRIPTION
New attempt. I've performed different benchmarks and appears that `Array.prototype.concat.apply` is faster than a loop. But it's unsafe to call on big arrays because it crashes with stack overflow.  That's why I propose to use the fast version on smaller arrays, and old on bigger.

Size limit (10000) is chosen to be safe. I didn't check exact limits, but Chrome and Firefox are ok with 10x this limit, whereas Safari only with 5x.

Here are some benchmark images. On all images `default` corresponds to current `concat`.

Smaller arrays 10x10 to 200x200.

![concat2](https://cloud.githubusercontent.com/assets/1089810/23331029/a78e2838-fb5d-11e6-8bec-f40d670086a1.png)

Bigger arrays 100x100 to 1000x1000.

![concat](https://cloud.githubusercontent.com/assets/1089810/23331045/ef45e184-fb5d-11e6-919f-b7f7a83c2ae5.png)

Small array (1..10) of big arrays with 100000 items.

![concat-small](https://cloud.githubusercontent.com/assets/1089810/23331059/21b702b0-fb5e-11e6-888f-444d61aa6130.png)

Next two are fallback to old methods. That's why results are same.

Big array with (100000..1000000) of small arrays of 1.

![concat-large](https://cloud.githubusercontent.com/assets/1089810/23331079/7687ccd4-fb5e-11e6-9ab7-33b427be550c.png)

Big array with (100000..1000000) small arrays of 10.

![concat-large2](https://cloud.githubusercontent.com/assets/1089810/23331084/8c65b160-fb5e-11e6-9dfc-a83a96e18939.png)

And here's a link to benchmark itself: <https://github.com/dikmax/purescript-array-benchmarks>.