### PR TITLE
partial functions for ST arrays

### DIFF
--- a/src/Data/Array/ST/Partial.js
+++ b/src/Data/Array/ST/Partial.js
@@ -1,0 +1,20 @@
+"use strict";
+
+exports.peekSTArray = function (xs) {
+  return function (i) {
+    return function () {
+      return xs[i];
+    };
+  };
+};
+
+exports.pokeSTArray = function (xs) {
+  return function (i) {
+    return function (a) {
+      return function () {
+        xs[i] = a;
+        return {};
+      };
+    };
+  };
+};

--- a/src/Data/Array/ST/Partial.purs
+++ b/src/Data/Array/ST/Partial.purs
@@ -1,0 +1,30 @@
+-- | Partial functions for working with mutable arrays using the `ST` effect.
+-- |
+-- | This module is particularly helpful when performance is very important.
+
+module Data.Array.ST.Partial
+  ( peekSTArray
+  , pokeSTArray
+  ) where
+
+import Control.Monad.Eff (Eff)
+import Control.Monad.ST (ST)
+import Data.Array.ST (STArray)
+import Data.Unit (Unit)
+
+-- | Read the value at the specified index in a mutable array.
+foreign import peekSTArray
+  :: forall a h r
+   . Partial
+  => STArray h a
+  -> Int
+  -> Eff (st :: ST h | r) a
+
+-- | Change the value at the specified index in a mutable array.
+foreign import pokeSTArray
+  :: forall a h r
+   . Partial
+  => STArray h a
+  -> Int
+  -> a
+  -> Eff (st :: ST h | r) Unit


### PR DESCRIPTION
I was surprised to see that partial functions exist for `Array` but not `STArray`, given the performance-sensitive contexts in which `STArray` is used. I've used these functions in `purescript-mersenne` (https://github.com/matthewleon/purescript-mersenne) to significantly increase performance in a tight loop.