### PR TITLE
Haskell inspired sortWith

### DIFF
--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -75,7 +75,7 @@ module Data.Array
 
   , sort
   , sortBy
-
+  , sortWith
   , slice
   , take
   , takeWhile
@@ -468,6 +468,11 @@ sortBy comp xs = sortImpl comp' xs
     GT -> 1
     EQ -> 0
     LT -> -1
+
+-- | Sort the elements of an array in increasing order, where elements are
+-- | sorted based on a projection
+sortWith :: forall a b. Ord b => (a -> b) -> Array a -> Array a
+sortWith f = sortBy (comparing f)
 
 foreign import sortImpl :: forall a. (a -> a -> Int) -> Array a -> Array a
 

--- a/test/Test/Data/Array.purs
+++ b/test/Test/Data/Array.purs
@@ -228,6 +228,9 @@ testArray = do
   log "sortBy should reorder a list into ascending order based on the result of a comparison function"
   assert $ A.sortBy (flip compare) [1, 3, 2, 5, 6, 4] == [6, 5, 4, 3, 2, 1]
 
+  log "sortWith should reorder a list into ascending order based on the result of compare over a projection"
+  assert $ A.sortWith id [1, 3, 2, 5, 6, 4] == [1, 2, 3, 4, 5, 6]
+
   log "take should keep the specified number of items from the front of an array, discarding the rest"
   assert $ (A.take 1 [1, 2, 3]) == [1]
   assert $ (A.take 2 [1, 2, 3]) == [1, 2]


### PR DESCRIPTION
Support for the GHC Ext `sortWith` function, which accepts a projection function.



http://hackage.haskell.org/package/base-4.9.1.0/docs/GHC-Exts.html#v:sortWith