### PR TITLE
Update npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "eslint": "^3.17.1",
-    "pulp": "^10.0.4",
-    "purescript-psa": "^0.5.0-rc.1",
+    "eslint": "^4.0.0",
+    "pulp": "^11.0.0",
+    "purescript-psa": "^0.5.1",
     "rimraf": "^2.6.1"
   }
 }

--- a/src/Data/Array.js
+++ b/src/Data/Array.js
@@ -41,8 +41,8 @@ var replicatePolyfill = function (count) {
 
 // In browsers that have Array.prototype.fill we use it, as it's faster.
 exports.replicate = typeof Array.prototype.fill === "function" ?
-    replicate :
-    replicatePolyfill;
+  replicate :
+  replicatePolyfill;
 
 exports.fromFoldableImpl = (function () {
   // jshint maxparams: 2


### PR DESCRIPTION
This means that the npm scripts for this project no longer rely on
wrapper scripts, but use the `purs` executable directly.