### PR TITLE
Preallocate result array for range

### DIFF
--- a/src/Data/Array.js
+++ b/src/Data/Array.js
@@ -7,7 +7,7 @@
 exports.range = function (start) {
   return function (end) {
     var step = start > end ? -1 : 1;
-    var result = [];
+    var result = new Array(step * (end - start));
     var i = start, n = 0;
     while (i !== end) {
       result[n++] = i;

--- a/src/Data/Array.js
+++ b/src/Data/Array.js
@@ -7,7 +7,7 @@
 exports.range = function (start) {
   return function (end) {
     var step = start > end ? -1 : 1;
-    var result = new Array(step * (end - start));
+    var result = new Array(step * (end - start) + 1);
     var i = start, n = 0;
     while (i !== end) {
       result[n++] = i;


### PR DESCRIPTION
For `range 0 1000`:

No prealloc:
```
   range/1000           6020.450 ns 0.998 r2       166100.536 ops/s 

```
Prealloc:

```
   range/1000           3720.389 ns 0.995 r2       268789.072 ops/s 
```
