### PR TITLE
shorten ST function names

### DIFF
--- a/src/Data/Array/ST.js
+++ b/src/Data/Array/ST.js
@@ -4,11 +4,11 @@ exports.runSTArray = function (f) {
   return f;
 };
 
-exports.emptySTArray = function () {
+exports.empty = function () {
   return [];
 };
 
-exports.peekSTArrayImpl = function (just) {
+exports.peekImpl = function (just) {
   return function (nothing) {
     return function (xs) {
       return function (i) {
@@ -20,7 +20,7 @@ exports.peekSTArrayImpl = function (just) {
   };
 };
 
-exports.pokeSTArray = function (xs) {
+exports.poke = function (xs) {
   return function (i) {
     return function (a) {
       return function () {
@@ -32,7 +32,7 @@ exports.pokeSTArray = function (xs) {
   };
 };
 
-exports.pushAllSTArray = function (xs) {
+exports.pushAll = function (xs) {
   return function (as) {
     return function () {
       return xs.push.apply(xs, as);
@@ -40,7 +40,7 @@ exports.pushAllSTArray = function (xs) {
   };
 };
 
-exports.spliceSTArray = function (xs) {
+exports.splice = function (xs) {
   return function (i) {
     return function (howMany) {
       return function (bs) {

--- a/src/Data/Array/ST/Iterator.purs
+++ b/src/Data/Array/ST/Iterator.purs
@@ -12,7 +12,7 @@ module Data.Array.ST.Iterator
 import Prelude
 import Control.Monad.Eff (Eff, whileE)
 import Control.Monad.ST (ST, STRef, newSTRef, readSTRef, writeSTRef, modifySTRef)
-import Data.Array.ST (STArray, pushSTArray)
+import Data.Array.ST (STArray, push)
 
 import Data.Maybe (Maybe(..), isNothing)
 
@@ -67,7 +67,7 @@ pushWhile p iter array = do
     mx <- peek iter
     case mx of
       Just x | p x -> do
-        _ <- pushSTArray array x
+        _ <- push array x
         void $ next iter
       _ ->
         void $ writeSTRef break true

--- a/src/Data/Array/ST/Partial.js
+++ b/src/Data/Array/ST/Partial.js
@@ -1,6 +1,6 @@
 "use strict";
 
-exports.peekSTArrayImpl = function (xs) {
+exports.peekImpl = function (xs) {
   return function (i) {
     return function () {
       return xs[i];
@@ -8,7 +8,7 @@ exports.peekSTArrayImpl = function (xs) {
   };
 };
 
-exports.pokeSTArrayImpl = function (xs) {
+exports.pokeImpl = function (xs) {
   return function (i) {
     return function (a) {
       return function () {

--- a/src/Data/Array/ST/Partial.purs
+++ b/src/Data/Array/ST/Partial.purs
@@ -3,7 +3,11 @@
 -- | This module is particularly helpful when performance is very important.
 
 module Data.Array.ST.Partial
-  ( peekSTArray
+  ( peek
+  , poke
+
+  -- deprecated
+  , peekSTArray
   , pokeSTArray
   ) where
 
@@ -13,31 +17,50 @@ import Data.Array.ST (STArray)
 import Data.Unit (Unit)
 
 -- | Read the value at the specified index in a mutable array.
-peekSTArray
+peek
   :: forall a h r
    . Partial
   => STArray h a
   -> Int
   -> Eff (st :: ST h | r) a
-peekSTArray = peekSTArrayImpl
+peek = peekImpl
 
-foreign import peekSTArrayImpl
+peekSTArray
+  :: forall a h r
+   . Warn "Deprecated `peekSTArray`, use `peek` instead."
+  => Partial
+  => STArray h a
+  -> Int
+  -> Eff (st :: ST h | r) a
+peekSTArray = peek
+
+foreign import peekImpl
   :: forall a h r
    . STArray h a
   -> Int
   -> Eff (st :: ST h | r) a
 
 -- | Change the value at the specified index in a mutable array.
-pokeSTArray
+poke
   :: forall a h r
    . Partial
   => STArray h a
   -> Int
   -> a
   -> Eff (st :: ST h | r) Unit
-pokeSTArray = pokeSTArrayImpl
+poke = pokeImpl
 
-foreign import pokeSTArrayImpl
+pokeSTArray
+  :: forall a h r
+   . Warn "Deprecated `peekSTArray`, use `peek` instead."
+  => Partial
+  => STArray h a
+  -> Int
+  -> a
+  -> Eff (st :: ST h | r) Unit
+pokeSTArray = poke
+
+foreign import pokeImpl
   :: forall a h r
    . STArray h a
   -> Int

--- a/test/Test/Data/Array/ST.purs
+++ b/test/Test/Data/Array/ST.purs
@@ -4,7 +4,7 @@ import Prelude
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (log, CONSOLE)
 import Control.Monad.ST (ST, pureST)
-import Data.Array.ST (STArray, emptySTArray, freeze, peekSTArray, pokeSTArray, pushAllSTArray, pushSTArray, spliceSTArray, thaw, toAssocArray, unsafeThaw, unsafeFreeze)
+import Data.Array.ST (STArray, empty, freeze, peek, poke, pushAll, push, splice, thaw, toAssocArray, unsafeThaw, unsafeFreeze)
 import Data.Foldable (all)
 import Data.Maybe (Maybe(..), isNothing)
 import Test.Assert (assert, ASSERT)
@@ -15,9 +15,9 @@ run act = pureST (act >>= unsafeFreeze)
 testArrayST :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
 testArrayST = do
 
-  log "emptySTArray should produce an empty array"
+  log "empty should produce an empty array"
 
-  assert $ run emptySTArray == nil
+  assert $ run empty == nil
 
   log "thaw should produce an STArray from a standard array"
 
@@ -33,130 +33,130 @@ testArrayST = do
 
   assert $ run (unsafeThaw [1, 2, 3]) == [1, 2, 3]
 
-  log "pushSTArray should append a value to the end of the array"
+  log "push should append a value to the end of the array"
 
   assert $ run (do
-    arr <- emptySTArray
-    void $ pushSTArray arr 1
-    void $ pushSTArray arr 2
+    arr <- empty
+    void $ push arr 1
+    void $ push arr 2
     pure arr) == [1, 2]
 
   assert $ run (do
     arr <- thaw [1, 2, 3]
-    void $ pushSTArray arr 4
+    void $ push arr 4
     pure arr) == [1, 2, 3, 4]
 
-  log "pushSTArray should return the new length of the array"
+  log "push should return the new length of the array"
 
   assert $ pureST (do
     arr <- thaw [unit, unit, unit]
-    pushSTArray arr unit) == 4
+    push arr unit) == 4
 
-  log "pushAllSTArray should append multiple values to the end of the array"
+  log "pushAll should append multiple values to the end of the array"
 
   assert $ run (do
-    arr <- emptySTArray
-    void $ pushAllSTArray arr [1, 2]
+    arr <- empty
+    void $ pushAll arr [1, 2]
     pure arr) == [1, 2]
 
   assert $ run (do
     arr <- thaw [1, 2, 3]
-    void $ pushAllSTArray arr [4, 5, 6]
+    void $ pushAll arr [4, 5, 6]
     pure arr) == [1, 2, 3, 4, 5, 6]
 
-  log "pushAllSTArray should return the new length of the array"
+  log "pushAll should return the new length of the array"
 
   assert $ pureST (do
     arr <- thaw [unit, unit, unit]
-    pushAllSTArray arr [unit, unit]) == 5
+    pushAll arr [unit, unit]) == 5
 
-  log "peekSTArray should return Nothing when peeking a value outside the array bounds"
+  log "peek should return Nothing when peeking a value outside the array bounds"
 
   assert $ isNothing $ pureST (do
-    arr <- emptySTArray
-    peekSTArray arr 0)
+    arr <- empty
+    peek arr 0)
 
   assert $ isNothing $ pureST (do
     arr <- thaw [1]
-    peekSTArray arr 1)
+    peek arr 1)
 
   assert $ isNothing $ pureST (do
-    arr <- emptySTArray
-    peekSTArray arr (-1))
+    arr <- empty
+    peek arr (-1))
 
-  log "peekSTArray should return the value at the specified index"
-
-  assert $ pureST (do
-    arr <- thaw [1]
-    peekSTArray arr 0) == Just 1
-
-  assert $ pureST (do
-    arr <- thaw [1, 2, 3]
-    peekSTArray arr 2) == Just 3
-
-  log "pokeSTArray should return true when a value has been updated succesfully"
+  log "peek should return the value at the specified index"
 
   assert $ pureST (do
     arr <- thaw [1]
-    pokeSTArray arr 0 10)
+    peek arr 0) == Just 1
 
   assert $ pureST (do
     arr <- thaw [1, 2, 3]
-    pokeSTArray arr 2 30)
+    peek arr 2) == Just 3
 
-  log "pokeSTArray should return false when attempting to modify a value outside the array bounds"
+  log "poke should return true when a value has been updated succesfully"
+
+  assert $ pureST (do
+    arr <- thaw [1]
+    poke arr 0 10)
+
+  assert $ pureST (do
+    arr <- thaw [1, 2, 3]
+    poke arr 2 30)
+
+  log "poke should return false when attempting to modify a value outside the array bounds"
 
   assert $ not $ pureST (do
-    arr <- emptySTArray
-    pokeSTArray arr 0 10)
+    arr <- empty
+    poke arr 0 10)
 
   assert $ not $ pureST (do
     arr <- thaw [1, 2, 3]
-    pokeSTArray arr 3 100)
+    poke arr 3 100)
 
   assert $ not $ pureST (do
     arr <- thaw [1, 2, 3]
-    pokeSTArray arr (-1) 100)
+    poke arr (-1) 100)
 
-  log "pokeSTArray should replace the value at the specified index"
+  log "poke should replace the value at the specified index"
 
   assert $ run (do
     arr <- thaw [1]
-    void $ pokeSTArray arr 0 10
+    void $ poke arr 0 10
     pure arr) == [10]
 
-  log "pokeSTArray should do nothing when attempting to modify a value outside the array bounds"
+  log "poke should do nothing when attempting to modify a value outside the array bounds"
 
   assert $ run (do
     arr <- thaw [1]
-    void $ pokeSTArray arr 1 2
+    void $ poke arr 1 2
     pure arr) == [1]
 
-  log "spliceSTArray should be able to delete multiple items at a specified index"
+  log "splice should be able to delete multiple items at a specified index"
 
   assert $ run (do
     arr <- thaw [1, 2, 3, 4, 5]
-    void $ spliceSTArray arr 1 3 []
+    void $ splice arr 1 3 []
     pure arr) == [1, 5]
 
-  log "spliceSTArray should return the items removed"
+  log "splice should return the items removed"
 
   assert $ pureST (do
     arr <- thaw [1, 2, 3, 4, 5]
-    spliceSTArray arr 1 3 []) == [2, 3, 4]
+    splice arr 1 3 []) == [2, 3, 4]
 
-  log "spliceSTArray should be able to insert multiple items at a specified index"
+  log "splice should be able to insert multiple items at a specified index"
 
   assert $ run (do
     arr <- thaw [1, 2, 3, 4, 5]
-    void $ spliceSTArray arr 1 0 [0, 100]
+    void $ splice arr 1 0 [0, 100]
     pure arr) == [1, 0, 100, 2, 3, 4, 5]
 
-  log "spliceSTArray should be able to delete and insert at the same time"
+  log "splice should be able to delete and insert at the same time"
 
   assert $ run (do
     arr <- thaw [1, 2, 3, 4, 5]
-    void $ spliceSTArray arr 1 2 [0, 100]
+    void $ splice arr 1 2 [0, 100]
     pure arr) == [1, 0, 100, 4, 5]
 
   log "toAssocArray should return all items in the array with the correct indices and values"

--- a/test/Test/Data/Array/ST/Partial.purs
+++ b/test/Test/Data/Array/ST/Partial.purs
@@ -7,7 +7,7 @@ import Control.Monad.Eff.Console (log, CONSOLE)
 import Control.Monad.ST (pureST)
 
 import Data.Array.ST (thaw, unsafeFreeze)
-import Data.Array.ST.Partial (peekSTArray, pokeSTArray)
+import Data.Array.ST.Partial (peek, poke)
 
 import Partial.Unsafe (unsafePartial)
 
@@ -16,13 +16,13 @@ import Test.Assert (assert, ASSERT)
 testArraySTPartial :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
 testArraySTPartial = do
 
-  log "peekSTArray should return the value at the specified index"
+  log "peek should return the value at the specified index"
   assert $ 2 == pureST do
     a <- thaw [1, 2, 3]
-    unsafePartial $ peekSTArray a 1
+    unsafePartial $ peek a 1
 
-  log "pokeSTArray should modify the value at the specified index"
+  log "poke should modify the value at the specified index"
   assert $ [1, 4, 3] == pureST do
     a <- thaw [1, 2, 3]
-    unsafePartial $ pokeSTArray a 1 4
+    unsafePartial $ poke a 1 4
     unsafeFreeze a


### PR DESCRIPTION
Deprecate old names.

Addresses https://github.com/purescript/purescript-arrays/issues/129