### PR TITLE
Fix a typo

### DIFF
--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -779,7 +779,7 @@ takeWhile p xs = (span p xs).init
 -- |
 foreign import drop :: forall a. Int -> Array a -> Array a
 
--- | Drop a number of elements from the start of an array, creating a new array.
+-- | Drop a number of elements from the end of an array, creating a new array.
 -- |
 -- | ```purescript
 -- | letters = ["a", "b", "c", "d"]


### PR DESCRIPTION
`dropEnd` drops elements from the *end* of an array.