### PR TITLE
Make groupBy stable

### DIFF
--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -866,8 +866,8 @@ groupBy op xs =
     iter <- STAI.iterator (xs !! _)
     STAI.iterate iter \x -> void do
       sub <- STA.empty
-      STAI.pushWhile (op x) iter sub
       _ <- STA.push x sub
+      STAI.pushWhile (op x) iter sub
       grp <- STA.unsafeFreeze sub
       STA.push ((unsafeCoerce :: Array ~> NonEmptyArray) grp) result
     STA.unsafeFreeze result

--- a/test/Test/Data/Array.purs
+++ b/test/Test/Data/Array.purs
@@ -306,6 +306,9 @@ testArray = do
   log "groupBy should group consecutive equal elements into arrays based on an equivalence relation"
   assert $ A.groupBy (\x y -> odd x && odd y) [1, 1, 2, 2, 3, 3] == [nea [1, 1], NEA.singleton 2, NEA.singleton 2, nea [3, 3]]
 
+  log "groupBy should be stable"
+  assert $ A.groupBy (\_ _ -> true) [1, 2, 3] == [nea [1, 2, 3]]
+
   log "nub should remove duplicate elements from the list, keeping the first occurence"
   assert $ A.nub [1, 2, 2, 3, 4, 1] == [1, 2, 3, 4]
 


### PR DESCRIPTION
Resolves https://github.com/purescript/purescript-arrays/issues/147

Now we have: `groupBy tt ([x] <> xs) = [NonEmptyArray x xs]`