### PR TITLE
Remove primes from foreign modules exports

### DIFF
--- a/src/Data/Array.js
+++ b/src/Data/Array.js
@@ -103,7 +103,7 @@ exports.snoc = function (l) {
 // Non-indexed reads -----------------------------------------------------------
 //------------------------------------------------------------------------------
 
-exports["uncons'"] = function (empty) {
+exports.unconsImpl = function (empty) {
   return function (next) {
     return function (xs) {
       return xs.length === 0 ? empty({}) : next(xs[0])(xs.slice(1));

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -309,7 +309,7 @@ last xs = xs !! (length xs - 1)
 -- |
 -- | Running time: `O(n)` where `n` is the length of the array
 tail :: forall a. Array a -> Maybe (Array a)
-tail = uncons' (const Nothing) (\_ xs -> Just xs)
+tail = unconsImpl (const Nothing) (\_ xs -> Just xs)
 
 -- | Get all but the last element of an array, creating a new array, or
 -- | `Nothing` if the array is empty.
@@ -340,9 +340,9 @@ init xs
 -- |   Nothing -> somethingElse
 -- | ```
 uncons :: forall a. Array a -> Maybe { head :: a, tail :: Array a }
-uncons = uncons' (const Nothing) \x xs -> Just { head: x, tail: xs }
+uncons = unconsImpl (const Nothing) \x xs -> Just { head: x, tail: xs }
 
-foreign import uncons'
+foreign import unconsImpl
   :: forall a b
    . (Unit -> b)
   -> (a -> Array a -> b)
@@ -1093,7 +1093,7 @@ unzip xs =
 -- | ```
 -- |
 foldM :: forall m a b. Monad m => (a -> b -> m a) -> a -> Array b -> m a
-foldM f a = uncons' (\_ -> pure a) (\b bs -> f a b >>= \a' -> foldM f a' bs)
+foldM f a = unconsImpl (\_ -> pure a) (\b bs -> f a b >>= \a' -> foldM f a' bs)
 
 foldRecM :: forall m a b. MonadRec m => (a -> b -> m a) -> a -> Array b -> m a
 foldRecM f a array = tailRecM2 go a 0


### PR DESCRIPTION
Primes in foreign modules exports will be deprecated in v0.14.0. See https://github.com/purescript/purescript/pull/3792.