### PR TITLE
Add roles declarations to allow safe coercions

### DIFF
--- a/src/Data/Array/ST.purs
+++ b/src/Data/Array/ST.purs
@@ -43,6 +43,8 @@ import Data.Maybe (Maybe(..))
 -- | except that mutation is allowed.
 foreign import data STArray :: Region -> Type -> Type
 
+type role STArray nominal representational
+
 -- | An element and its index.
 type Assoc a = { value :: a, index :: Int }
 


### PR DESCRIPTION
This allows terms of type `STArray r a` to be coerced to type `STArray r b` when `Coercible a b` holds, hence allowing the zero cost `coerce` instead of `map wrap` and `map unwrap` to introduce and eliminate newtypes under ST arrays for instance.

I couldn’t think of a case where a phantom roled region is an issue but in doubt I preferred to keep it nominal.