### PR TITLE
Remove some usages of unsafeCoerce

### DIFF
--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -123,7 +123,7 @@ import Control.Alternative (class Alternative)
 import Control.Lazy (class Lazy, defer)
 import Control.Monad.Rec.Class (class MonadRec, Step(..), tailRecM2)
 import Control.Monad.ST as ST
-import Data.Array.NonEmpty.Internal (NonEmptyArray)
+import Data.Array.NonEmpty.Internal (NonEmptyArray(..))
 import Data.Array.ST as STA
 import Data.Array.ST.Iterator as STAI
 import Data.Foldable (class Foldable, foldl, foldr, traverse_)
@@ -134,7 +134,6 @@ import Data.Traversable (sequence, traverse)
 import Data.Tuple (Tuple(..), fst, snd)
 import Data.Unfoldable (class Unfoldable, unfoldr)
 import Partial.Unsafe (unsafePartial)
-import Unsafe.Coerce (unsafeCoerce)
 
 -- | Convert an `Array` into an `Unfoldable` structure.
 toUnfoldable :: forall f. Unfoldable f => Array ~> f
@@ -895,7 +894,7 @@ groupBy op xs =
       _ <- STA.push x sub
       STAI.pushWhile (op x) iter sub
       grp <- STA.unsafeFreeze sub
-      STA.push ((unsafeCoerce :: Array ~> NonEmptyArray) grp) result
+      STA.push (NonEmptyArray grp) result
     STA.unsafeFreeze result
 
 -- | Remove the duplicates from an array, creating a new array.

--- a/src/Data/Array/NonEmpty.purs
+++ b/src/Data/Array/NonEmpty.purs
@@ -1,5 +1,5 @@
 module Data.Array.NonEmpty
-  ( module Data.Array.NonEmpty.Internal
+  ( module Internal
   , fromArray
   , fromNonEmpty
   , toArray
@@ -101,7 +101,8 @@ import Control.Alternative (class Alternative)
 import Control.Lazy (class Lazy)
 import Control.Monad.Rec.Class (class MonadRec)
 import Data.Array as A
-import Data.Array.NonEmpty.Internal (NonEmptyArray)
+import Data.Array.NonEmpty.Internal (NonEmptyArray(..))
+import Data.Array.NonEmpty.Internal (NonEmptyArray) as Internal
 import Data.Bifunctor (bimap)
 import Data.Foldable (class Foldable)
 import Data.Maybe (Maybe(..), fromJust)
@@ -139,7 +140,7 @@ fromArray xs
 
 -- | INTERNAL
 unsafeFromArray :: forall a. Array a -> NonEmptyArray a
-unsafeFromArray = unsafeCoerce
+unsafeFromArray = NonEmptyArray
 
 unsafeFromArrayF :: forall f a. f (Array a) -> f (NonEmptyArray a)
 unsafeFromArrayF = unsafeCoerce
@@ -148,7 +149,7 @@ fromNonEmpty :: forall a. NonEmpty Array a -> NonEmptyArray a
 fromNonEmpty (x :| xs) = cons' x xs
 
 toArray :: forall a. NonEmptyArray a -> Array a
-toArray = unsafeCoerce
+toArray (NonEmptyArray xs) = xs
 
 toNonEmpty :: forall a. NonEmptyArray a -> NonEmpty Array a
 toNonEmpty = uncons >>> \{head: x, tail: xs} -> x :| xs

--- a/src/Data/Array/NonEmpty/Internal.purs
+++ b/src/Data/Array/NonEmpty/Internal.purs
@@ -1,4 +1,7 @@
-module Data.Array.NonEmpty.Internal (NonEmptyArray) where
+-- | This module exports the `NonEmptyArray` constructor, which can be
+-- | overlooked when searching for issues in one's code. See the
+-- | constructor's documentation for more information.
+module Data.Array.NonEmpty.Internal (NonEmptyArray(..)) where
 
 import Prelude
 
@@ -14,6 +17,13 @@ import Data.Traversable (class Traversable)
 import Data.TraversableWithIndex (class TraversableWithIndex)
 import Data.Unfoldable1 (class Unfoldable1)
 
+-- | An array that is known not to be empty.
+-- |
+-- | You can use the constructor to create a `NonEmptyArray` that isn't
+-- | non-empty, breaking the guarantee behind this newtype. It is
+-- | provided as an escape hatch mainly for the `Data.Array.NonEmpty`
+-- | and `Data.Array` modules. Use this at your own risk when you know
+-- | what you are doing.
 newtype NonEmptyArray a = NonEmptyArray (Array a)
 
 instance showNonEmptyArray :: Show a => Show (NonEmptyArray a) where

--- a/src/Data/Array/NonEmpty/Internal.purs
+++ b/src/Data/Array/NonEmpty/Internal.purs
@@ -1,6 +1,10 @@
--- | This module exports the `NonEmptyArray` constructor, which can be
--- | overlooked when searching for issues in one's code. See the
--- | constructor's documentation for more information.
+-- | This module exports the `NonEmptyArray` constructor.
+-- |
+-- | It is **NOT** intended for public use and is **NOT** versioned.
+-- |
+-- | Its content may change **in any way**, **at any time** and
+-- | **without notice**.
+
 module Data.Array.NonEmpty.Internal (NonEmptyArray(..)) where
 
 import Prelude


### PR DESCRIPTION
This pull request replace some usages of `unsafeCoerce`, not by `coerce` like I suggested in https://github.com/purescript/purescript-arrays/pull/181#issuecomment-716061771 but by matching on and applying the `NonEmptyArray` constructor itself as done in https://github.com/purescript/purescript-strings/pull/130. I also adapted the comments from the other pull request.