### PR TITLE
Add short circuiting functions of `elem`, `notElem`, `find`, `findMap`, `scanl`, and `scanr`

### DIFF
--- a/src/Data/Array.js
+++ b/src/Data/Array.js
@@ -236,6 +236,34 @@ exports.partition = function (f) {
   };
 };
 
+exports.scanlImpl = function (f) {
+  return function (b) {
+    return function (xs) {
+      var acc = b;
+      var out = [];
+      for (var i = 0; i < xs.length; i++) {
+        acc = f(acc)(xs[i]);
+        out.push(acc);
+      }
+      return out;
+    };
+  };
+};
+
+exports.scanrImpl = function (f) {
+  return function (b) {
+    return function (xs) {
+      var acc = b;
+      var out = [];
+      for (var i = xs.length - 1; i >= 0; i--) {
+        acc = f(xs[i])(acc);
+        out.push(acc);
+      }
+      return out.reverse();
+    };
+  };
+};
+
 //------------------------------------------------------------------------------
 // Sorting ---------------------------------------------------------------------
 //------------------------------------------------------------------------------

--- a/src/Data/Array.js
+++ b/src/Data/Array.js
@@ -107,6 +107,20 @@ exports.indexImpl = function (just) {
   };
 };
 
+exports.findMapImpl = function (nothing) {
+  return function (isJust) {
+    return function (f) {
+      return function (xs) {
+        for (var i = 0; i < xs.length; i++) {
+          var result = f(xs[i]);
+          if (isJust(result)) return result;
+        }
+        return nothing;
+      };
+    };
+  };
+};
+
 exports.findIndexImpl = function (just) {
   return function (nothing) {
     return function (f) {

--- a/src/Data/Array.js
+++ b/src/Data/Array.js
@@ -236,7 +236,7 @@ exports.partition = function (f) {
   };
 };
 
-exports.scanlImpl = function (f) {
+exports.scanl = function (f) {
   return function (b) {
     return function (xs) {
       var len = xs.length;
@@ -251,7 +251,7 @@ exports.scanlImpl = function (f) {
   };
 };
 
-exports.scanrImpl = function (f) {
+exports.scanr = function (f) {
   return function (b) {
     return function (xs) {
       var len = xs.length;

--- a/src/Data/Array.js
+++ b/src/Data/Array.js
@@ -239,11 +239,12 @@ exports.partition = function (f) {
 exports.scanlImpl = function (f) {
   return function (b) {
     return function (xs) {
+      var len = xs.length;
       var acc = b;
-      var out = [];
-      for (var i = 0; i < xs.length; i++) {
+      var out = new Array(len);
+      for (var i = 0; i < len; i++) {
         acc = f(acc)(xs[i]);
-        out.push(acc);
+        out[i] = acc;
       }
       return out;
     };
@@ -253,13 +254,14 @@ exports.scanlImpl = function (f) {
 exports.scanrImpl = function (f) {
   return function (b) {
     return function (xs) {
+      var len = xs.length;
       var acc = b;
-      var out = [];
-      for (var i = xs.length - 1; i >= 0; i--) {
+      var out = new Array(len);
+      for (var i = len - 1; i >= 0; i--) {
         acc = f(xs[i])(acc);
-        out.push(acc);
+        out[i] = acc;
       }
-      return out.reverse();
+      return out;
     };
   };
 };

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -135,7 +135,6 @@ import Data.Array.ST.Iterator as STAI
 import Data.Foldable (class Foldable, foldl, foldr, traverse_)
 import Data.Foldable (foldl, foldr, foldMap, fold, intercalate, any, all) as Exports
 import Data.Maybe (Maybe(..), maybe, isJust, fromJust, isNothing)
-import Data.Traversable (scanl, scanr) as Exports
 import Data.Traversable (sequence, traverse)
 import Data.Tuple (Tuple(..), fst, snd)
 import Data.Unfoldable (class Unfoldable, unfoldr)

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -57,6 +57,7 @@ module Data.Array
   , elemIndex
   , elemLastIndex
   , find
+  , findMap
   , findIndex
   , findLastIndex
   , insertAt
@@ -130,7 +131,7 @@ import Data.Array.NonEmpty.Internal (NonEmptyArray(..))
 import Data.Array.ST as STA
 import Data.Array.ST.Iterator as STAI
 import Data.Foldable (class Foldable, foldl, foldr, traverse_)
-import Data.Foldable (foldl, foldr, foldMap, fold, intercalate, findMap, any, all) as Exports
+import Data.Foldable (foldl, foldr, foldMap, fold, intercalate, any, all) as Exports
 import Data.Maybe (Maybe(..), maybe, isJust, fromJust, isNothing)
 import Data.Traversable (scanl, scanr) as Exports
 import Data.Traversable (sequence, traverse)
@@ -435,6 +436,19 @@ elemLastIndex x = findLastIndex (_ == x)
 -- | ```
 find :: forall a. (a -> Boolean) -> Array a -> Maybe a
 find f xs = unsafePartial (unsafeIndex xs) <$> findIndex f xs
+
+-- | Find the first element in a data structure which satisfies
+-- | a predicate mapping.
+findMap :: forall a b. (a -> Maybe b) -> Array a -> Maybe b
+findMap = findMapImpl Nothing isJust
+
+foreign import findMapImpl
+  :: forall a b
+   . (forall c. Maybe c)
+  -> (forall c. Maybe c -> Boolean)
+  -> (a -> Maybe b)
+  -> Array a
+  -> Maybe b
 
 -- | Find the first index for which a predicate holds.
 -- |

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -54,6 +54,7 @@ module Data.Array
   , (!!), index
   , elemIndex
   , elemLastIndex
+  , find
   , findIndex
   , findLastIndex
   , insertAt
@@ -127,7 +128,7 @@ import Data.Array.NonEmpty.Internal (NonEmptyArray(..))
 import Data.Array.ST as STA
 import Data.Array.ST.Iterator as STAI
 import Data.Foldable (class Foldable, foldl, foldr, traverse_)
-import Data.Foldable (foldl, foldr, foldMap, fold, intercalate, elem, notElem, find, findMap, any, all) as Exports
+import Data.Foldable (foldl, foldr, foldMap, fold, intercalate, elem, notElem, findMap, any, all) as Exports
 import Data.Maybe (Maybe(..), maybe, isJust, fromJust)
 import Data.Traversable (scanl, scanr) as Exports
 import Data.Traversable (sequence, traverse)
@@ -417,6 +418,15 @@ elemIndex x = findIndex (_ == x)
 -- |
 elemLastIndex :: forall a. Eq a => a -> Array a -> Maybe Int
 elemLastIndex x = findLastIndex (_ == x)
+
+-- | Find the first element for which a predicate holds.
+-- |
+-- | ```purescript
+-- | findIndex (contains $ Pattern "b") ["a", "bb", "b", "d"] = Just "bb"
+-- | findIndex (contains $ Pattern "x") ["a", "bb", "b", "d"] = Nothing
+-- | ```
+find :: forall a. (a -> Boolean) -> Array a -> Maybe a
+find f xs = unsafePartial (unsafeIndex xs) <$> findIndex f xs
 
 -- | Find the first index for which a predicate holds.
 -- |

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -78,6 +78,8 @@ module Data.Array
   , mapMaybe
   , catMaybes
   , mapWithIndex
+  , scanl
+  , scanr
 
   , sort
   , sortBy
@@ -729,6 +731,32 @@ updateAtIndices us xs =
 modifyAtIndices :: forall t a. Foldable t => t Int -> (a -> a) -> Array a -> Array a
 modifyAtIndices is f xs =
   ST.run (STA.withArray (\res -> traverse_ (\i -> STA.modify i f res) is) xs)
+
+-- | Fold a data structure from the left, keeping all intermediate results
+-- | instead of only the final result. Note that the initial value does not
+-- | appear in the result (unlike Haskell's `Prelude.scanl`).
+-- |
+-- | ```
+-- | scanl (+) 0  [1,2,3] = [1,3,6]
+-- | scanl (-) 10 [1,2,3] = [9,7,4]
+-- | ```
+scanl :: forall a b. (b -> a -> b) -> b -> Array a -> Array b
+scanl = scanlImpl
+
+foreign import scanlImpl :: forall a b. (b -> a -> b) -> b -> Array a -> Array b
+
+-- | Fold a data structure from the right, keeping all intermediate results
+-- | instead of only the final result. Note that the initial value does not
+-- | appear in the result (unlike Haskell's `Prelude.scanr`).
+-- |
+-- | ```
+-- | scanr (+) 0 [1,2,3] = [6,5,3]
+-- | scanr (flip (-)) 10 [1,2,3] = [4,5,7]
+-- | ```
+scanr :: forall a b. (a -> b -> b) -> b -> Array a -> Array b
+scanr = scanrImpl
+
+foreign import scanrImpl :: forall a b. (a -> b -> b) -> b -> Array a -> Array b
 
 --------------------------------------------------------------------------------
 -- Sorting ---------------------------------------------------------------------

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -741,10 +741,7 @@ modifyAtIndices is f xs =
 -- | scanl (+) 0  [1,2,3] = [1,3,6]
 -- | scanl (-) 10 [1,2,3] = [9,7,4]
 -- | ```
-scanl :: forall a b. (b -> a -> b) -> b -> Array a -> Array b
-scanl = scanlImpl
-
-foreign import scanlImpl :: forall a b. (b -> a -> b) -> b -> Array a -> Array b
+foreign import scanl :: forall a b. (b -> a -> b) -> b -> Array a -> Array b
 
 -- | Fold a data structure from the right, keeping all intermediate results
 -- | instead of only the final result. Note that the initial value does not
@@ -754,10 +751,7 @@ foreign import scanlImpl :: forall a b. (b -> a -> b) -> b -> Array a -> Array b
 -- | scanr (+) 0 [1,2,3] = [6,5,3]
 -- | scanr (flip (-)) 10 [1,2,3] = [4,5,7]
 -- | ```
-scanr :: forall a b. (a -> b -> b) -> b -> Array a -> Array b
-scanr = scanrImpl
-
-foreign import scanrImpl :: forall a b. (a -> b -> b) -> b -> Array a -> Array b
+foreign import scanr :: forall a b. (a -> b -> b) -> b -> Array a -> Array b
 
 --------------------------------------------------------------------------------
 -- Sorting ---------------------------------------------------------------------

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -404,9 +404,11 @@ foreign import indexImpl
 -- |
 infixl 8 index as !!
 
+-- | Returns true if the array has the given element.
 elem :: forall a. Eq a => a -> Array a -> Boolean
 elem a arr = isJust $ elemIndex a arr
 
+-- | Returns true if the array does not have the given element.
 notElem :: forall a. Eq a => a -> Array a -> Boolean
 notElem a arr = isNothing $ elemIndex a arr
 

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -52,6 +52,8 @@ module Data.Array
   , unsnoc
 
   , (!!), index
+  , elem
+  , notElem
   , elemIndex
   , elemLastIndex
   , find
@@ -128,8 +130,8 @@ import Data.Array.NonEmpty.Internal (NonEmptyArray(..))
 import Data.Array.ST as STA
 import Data.Array.ST.Iterator as STAI
 import Data.Foldable (class Foldable, foldl, foldr, traverse_)
-import Data.Foldable (foldl, foldr, foldMap, fold, intercalate, elem, notElem, findMap, any, all) as Exports
-import Data.Maybe (Maybe(..), maybe, isJust, fromJust)
+import Data.Foldable (foldl, foldr, foldMap, fold, intercalate, findMap, any, all) as Exports
+import Data.Maybe (Maybe(..), maybe, isJust, fromJust, isNothing)
 import Data.Traversable (scanl, scanr) as Exports
 import Data.Traversable (sequence, traverse)
 import Data.Tuple (Tuple(..), fst, snd)
@@ -398,6 +400,12 @@ foreign import indexImpl
 -- | ```
 -- |
 infixl 8 index as !!
+
+elem :: forall a. Eq a => a -> Array a -> Boolean
+elem a arr = isJust $ elemIndex a arr
+
+notElem :: forall a. Eq a => a -> Array a -> Boolean
+notElem a arr = isNothing $ elemIndex a arr
 
 -- | Find the index of the first element equal to the specified element.
 -- |

--- a/test/Test/Data/Array.purs
+++ b/test/Test/Data/Array.purs
@@ -131,6 +131,14 @@ testArray = do
   assert $ [1, 2, 3] !! 6 == Nothing
   assert $ [1, 2, 3] !! (-1) == Nothing
 
+  log "elem should return true if the array contains the given element at least once"
+  assert $ (A.elem 1 [1, 2, 1]) == true
+  assert $ (A.elem 4 [1, 2, 1]) == false
+
+  log "notElem should return true if the array does not contain the given element"
+  assert $ (A.notElem 1 [1, 2, 1]) == false
+  assert $ (A.notElem 4 [1, 2, 1]) == true
+
   log "elemIndex should return the index of an item that a predicate returns true for in an array"
   assert $ (A.elemIndex 1 [1, 2, 1]) == Just 0
   assert $ (A.elemIndex 4 [1, 2, 1]) == Nothing

--- a/test/Test/Data/Array.purs
+++ b/test/Test/Data/Array.purs
@@ -152,9 +152,9 @@ testArray = do
   assert $ (A.find (_ == 3) [1, 2, 1]) == Nothing
 
   log "findMap should return the mapping of the first element that satisfies the given predicate"
-  assert $ (A.findMap (\x -> if x > 3 then Just "foo" else Nothing) [1, 2, 4]) == Just "foo"
-  assert $ (A.findMap (\x -> if x > 3 then Just "foo" else Nothing) [1, 2, 1]) == Nothing
-  assert $ (A.findMap (\x -> if x > 3 then Just "foo" else Nothing) [4, 1, 4]) == Just "foo"
+  assert $ (A.findMap (\x -> if x > 3 then Just x else Nothing) [1, 2, 4]) == Just 4
+  assert $ (A.findMap (\x -> if x > 3 then Just x else Nothing) [1, 2, 1]) == Nothing
+  assert $ (A.findMap (\x -> if x > 3 then Just x else Nothing) [4, 1, 5]) == Just 4
 
   log "findIndex should return the index of an item that a predicate returns true for in an array"
   assert $ (A.findIndex (_ /= 1) [1, 2, 1]) == Just 1

--- a/test/Test/Data/Array.purs
+++ b/test/Test/Data/Array.purs
@@ -6,7 +6,7 @@ import Data.Array ((:), (\\), (!!))
 import Data.Array as A
 import Data.Array.NonEmpty as NEA
 import Data.Const (Const(..))
-import Data.Foldable (for_, foldMapDefaultR, class Foldable, all, traverse_)
+import Data.Foldable (for_, foldMapDefaultR, class Foldable, all, traverse_, scanl, scanr)
 import Data.Maybe (Maybe(..), isNothing, fromJust)
 import Data.Tuple (Tuple(..))
 import Data.Unfoldable (replicateA)
@@ -258,9 +258,17 @@ testArray = do
   assert $ A.scanl (+)  0 [1,2,3] == [1, 3, 6]
   assert $ A.scanl (-) 10 [1,2,3] == [9, 7, 4]
 
+  log "scanl should return the same results as its Foldable counterpart"
+  assert $ A.scanl (+)  0 [1,2,3] == scanl (+) 0 [1,2,3]
+  assert $ A.scanl (-) 10 [1,2,3] == scanl (-) 10 [1,2,3]
+
   log "scanr should return an array that stores the accumulated value at each step"
   assert $ A.scanr (+) 0 [1,2,3] == [6,5,3]
   assert $ A.scanr (flip (-)) 10 [1,2,3] == [4,5,7]
+
+  log "scanr should return the same results as its Foldable counterpart"
+  assert $ A.scanr (+) 0 [1,2,3] == scanr (+) 0 [1,2,3]
+  assert $ A.scanr (flip (-)) 10 [1,2,3] == scanr (flip (-)) 10 [1,2,3]
 
   log "sort should reorder a list into ascending order based on the result of compare"
   assert $ A.sort [1, 3, 2, 5, 6, 4] == [1, 2, 3, 4, 5, 6]

--- a/test/Test/Data/Array.purs
+++ b/test/Test/Data/Array.purs
@@ -154,6 +154,7 @@ testArray = do
   log "findMap should return the mapping of the first element that satisfies the given predicate"
   assert $ (A.findMap (\x -> if x > 3 then Just "foo" else Nothing) [1, 2, 4]) == Just "foo"
   assert $ (A.findMap (\x -> if x > 3 then Just "foo" else Nothing) [1, 2, 1]) == Nothing
+  assert $ (A.findMap (\x -> if x > 3 then Just "foo" else Nothing) [4, 1, 4]) == Just "foo"
 
   log "findIndex should return the index of an item that a predicate returns true for in an array"
   assert $ (A.findIndex (_ /= 1) [1, 2, 1]) == Just 1

--- a/test/Test/Data/Array.purs
+++ b/test/Test/Data/Array.purs
@@ -6,7 +6,8 @@ import Data.Array ((:), (\\), (!!))
 import Data.Array as A
 import Data.Array.NonEmpty as NEA
 import Data.Const (Const(..))
-import Data.Foldable (for_, foldMapDefaultR, class Foldable, all, traverse_, scanl, scanr)
+import Data.Foldable (for_, foldMapDefaultR, class Foldable, all, traverse_)
+import Data.Traversable (scanl, scanr)
 import Data.Maybe (Maybe(..), isNothing, fromJust)
 import Data.Tuple (Tuple(..))
 import Data.Unfoldable (replicateA)

--- a/test/Test/Data/Array.purs
+++ b/test/Test/Data/Array.purs
@@ -151,6 +151,10 @@ testArray = do
   assert $ (A.find (_ /= 1) [1, 2, 1]) == Just 2
   assert $ (A.find (_ == 3) [1, 2, 1]) == Nothing
 
+  log "findMap should return the mapping of the first element that satisfies the given predicate"
+  assert $ (A.findMap (\x -> if x > 3 then Just "foo" else Nothing) [1, 2, 4]) == Just "foo"
+  assert $ (A.findMap (\x -> if x > 3 then Just "foo" else Nothing) [1, 2, 1]) == Nothing
+
   log "findIndex should return the index of an item that a predicate returns true for in an array"
   assert $ (A.findIndex (_ /= 1) [1, 2, 1]) == Just 1
   assert $ (A.findIndex (_ == 3) [1, 2, 1]) == Nothing

--- a/test/Test/Data/Array.purs
+++ b/test/Test/Data/Array.purs
@@ -139,6 +139,10 @@ testArray = do
   assert $ (A.elemLastIndex 1 [1, 2, 1]) == Just 2
   assert $ (A.elemLastIndex 4 [1, 2, 1]) == Nothing
 
+  log "find should return the first element for which a predicate returns true in an array"
+  assert $ (A.find (_ /= 1) [1, 2, 1]) == Just 2
+  assert $ (A.find (_ == 3) [1, 2, 1]) == Nothing
+
   log "findIndex should return the index of an item that a predicate returns true for in an array"
   assert $ (A.findIndex (_ /= 1) [1, 2, 1]) == Just 1
   assert $ (A.findIndex (_ == 3) [1, 2, 1]) == Nothing

--- a/test/Test/Data/Array.purs
+++ b/test/Test/Data/Array.purs
@@ -253,6 +253,14 @@ testArray = do
   assert $ A.modifyAtIndices [0, 2, 8] not [true,  true, true,  true] ==
                                            [false, true, false, true]
 
+  log "scanl should return an array that stores the accumulated value at each step"
+  assert $ A.scanl (+)  0 [1,2,3] == [1, 3, 6]
+  assert $ A.scanl (-) 10 [1,2,3] == [9, 7, 4]
+
+  log "scanr should return an array that stores the accumulated value at each step"
+  assert $ A.scanr (+) 0 [1,2,3] == [6,5,3]
+  assert $ A.scanr (flip (-)) 10 [1,2,3] == [4,5,7]
+
   log "sort should reorder a list into ascending order based on the result of compare"
   assert $ A.sort [1, 3, 2, 5, 6, 4] == [1, 2, 3, 4, 5, 6]
 


### PR DESCRIPTION
See https://github.com/purescript/purescript-arrays/pull/173#issuecomment-734956092