### PR TITLE
Move unsafeFreeze and unsafeThaw into Data.Array.ST.Unsafe

### DIFF
--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -124,7 +124,8 @@ import Control.Lazy (class Lazy, defer)
 import Control.Monad.Rec.Class (class MonadRec, Step(..), tailRecM2)
 import Control.Monad.ST as ST
 import Data.Array.NonEmpty.Internal (NonEmptyArray(..))
-import Data.Array.ST as STA
+import Data.Array.ST (empty, modify, poke, push, withArray) as STA
+import Data.Array.ST.Unsafe (unsafeFreeze, unsafeThaw) as STA
 import Data.Array.ST.Iterator as STAI
 import Data.Foldable (class Foldable, foldl, foldr, traverse_)
 import Data.Foldable (foldl, foldr, foldMap, fold, intercalate, elem, notElem, find, findMap, any, all) as Exports

--- a/src/Data/Array/ST.js
+++ b/src/Data/Array/ST.js
@@ -76,18 +76,6 @@ exports.splice = function (i) {
   };
 };
 
-exports.unsafeFreeze = function (xs) {
-  return function () {
-    return xs;
-  };
-};
-
-exports.unsafeThaw = function (xs) {
-  return function () {
-    return xs;
-  };
-};
-
 function copyImpl(xs) {
   return function () {
     return xs.slice();

--- a/src/Data/Array/ST.purs
+++ b/src/Data/Array/ST.purs
@@ -3,7 +3,7 @@
 -- | This module can be used when performance is important and mutation is a local effect.
 
 module Data.Array.ST
-  ( STArray(..)
+  ( module Data.Array.ST.Internal
   , Assoc
   , run
   , withArray
@@ -23,27 +23,16 @@ module Data.Array.ST
   , sortWith
   , freeze
   , thaw
-  , unsafeFreeze
-  , unsafeThaw
   , toAssocArray
   ) where
 
 import Prelude
 
 import Control.Monad.ST as ST
-import Control.Monad.ST (ST, Region)
+import Control.Monad.ST (ST)
+import Data.Array.ST.Internal (STArray)
+import Data.Array.ST.Unsafe (unsafeFreeze)
 import Data.Maybe (Maybe(..))
-
--- | A reference to a mutable array.
--- |
--- | The first type parameter represents the memory region which the array belongs to.
--- | The second type parameter defines the type of elements of the mutable array.
--- |
--- | The runtime representation of a value of type `STArray h a` is the same as that of `Array a`,
--- | except that mutation is allowed.
-foreign import data STArray :: Region -> Type -> Type
-
-type role STArray nominal representational
 
 -- | An element and its index.
 type Assoc a = { value :: a, index :: Int }
@@ -66,14 +55,6 @@ withArray f xs = do
   result <- thaw xs
   _ <- f result
   unsafeFreeze result
-
--- | O(1). Convert a mutable array to an immutable array, without copying. The mutable
--- | array must not be mutated afterwards.
-foreign import unsafeFreeze :: forall h a. STArray h a -> ST h (Array a)
-
--- | O(1) Convert an immutable array to a mutable array, without copying. The input
--- | array must not be used afterward.
-foreign import unsafeThaw :: forall h a. Array a -> ST h (STArray h a)
 
 -- | Create an empty mutable array.
 foreign import empty :: forall h a. ST h (STArray h a)

--- a/src/Data/Array/ST/Internal.purs
+++ b/src/Data/Array/ST/Internal.purs
@@ -1,0 +1,14 @@
+module Data.Array.ST.Internal where
+
+import Control.Monad.ST (Region)
+
+-- | A reference to a mutable array.
+-- |
+-- | The first type parameter represents the memory region which the array belongs to.
+-- | The second type parameter defines the type of elements of the mutable array.
+-- |
+-- | The runtime representation of a value of type `STArray h a` is the same as that of `Array a`,
+-- | except that mutation is allowed.
+foreign import data STArray :: Region -> Type -> Type
+
+type role STArray nominal representational

--- a/src/Data/Array/ST/Unsafe.js
+++ b/src/Data/Array/ST/Unsafe.js
@@ -1,0 +1,13 @@
+"use strict";
+
+exports.unsafeFreeze = function (xs) {
+  return function () {
+    return xs;
+  };
+};
+
+exports.unsafeThaw = function (xs) {
+  return function () {
+    return xs;
+  };
+};

--- a/src/Data/Array/ST/Unsafe.purs
+++ b/src/Data/Array/ST/Unsafe.purs
@@ -1,0 +1,12 @@
+module Data.Array.ST.Unsafe where
+
+import Control.Monad.ST (ST)
+import Data.Array.ST.Internal (STArray)
+
+-- | O(1). Convert a mutable array to an immutable array, without copying. The mutable
+-- | array must not be mutated afterwards.
+foreign import unsafeFreeze :: forall h a. STArray h a -> ST h (Array a)
+
+-- | O(1) Convert an immutable array to a mutable array, without copying. The input
+-- | array must not be used afterward.
+foreign import unsafeThaw :: forall h a. Array a -> ST h (STArray h a)

--- a/test/Test/Data/Array/ST.purs
+++ b/test/Test/Data/Array/ST.purs
@@ -5,6 +5,7 @@ import Prelude
 import Control.Monad.ST as ST
 import Data.Array.ST (withArray)
 import Data.Array.ST as STA
+import Data.Array.ST.Unsafe (unsafeThaw)
 import Data.Foldable (all)
 import Data.Maybe (Maybe(..), isNothing)
 import Effect (Effect)
@@ -44,7 +45,7 @@ testArrayST = do
 
   log "unsafeThaw should produce an STArray from a standard array"
 
-  assert $ STA.run (STA.unsafeThaw [1, 2, 3]) == [1, 2, 3]
+  assert $ STA.run (unsafeThaw [1, 2, 3]) == [1, 2, 3]
 
   log "pop should remove elements from an STArray"
 
@@ -222,17 +223,17 @@ testArrayST = do
 
   log "sort should reorder a list into ascending order based on the result of compare"
   assert $ STA.run (
-    STA.sort =<< STA.unsafeThaw [1, 3, 2, 5, 6, 4]
+    STA.sort =<< unsafeThaw [1, 3, 2, 5, 6, 4]
   ) == [1, 2, 3, 4, 5, 6]
 
   log "sortBy should reorder a list into ascending order based on the result of a comparison function"
   assert $ STA.run (
-    STA.sortBy (flip compare) =<< STA.unsafeThaw [1, 3, 2, 5, 6, 4]
+    STA.sortBy (flip compare) =<< unsafeThaw [1, 3, 2, 5, 6, 4]
   ) == [6, 5, 4, 3, 2, 1]
 
   log "sortWith should reorder a list into ascending order based on the result of compare over a projection"
   assert $ STA.run (
-    STA.sortWith identity =<< STA.unsafeThaw [1, 3, 2, 5, 6, 4]
+    STA.sortWith identity =<< unsafeThaw [1, 3, 2, 5, 6, 4]
   ) == [1, 2, 3, 4, 5, 6]
 
   log "splice should be able to delete multiple items at a specified index"

--- a/test/Test/Data/Array/ST/Partial.purs
+++ b/test/Test/Data/Array/ST/Partial.purs
@@ -3,7 +3,8 @@ module Test.Data.Array.ST.Partial (testArraySTPartial) where
 import Prelude
 
 import Control.Monad.ST as ST
-import Data.Array.ST (thaw, unsafeFreeze)
+import Data.Array.ST (thaw)
+import Data.Array.ST.Unsafe (unsafeFreeze)
 import Data.Array.ST.Partial as STAP
 import Effect (Effect)
 import Effect.Console (log)


### PR DESCRIPTION
This pull request deprecate Data.Array.ST.unsafeFreeze and Data.Array.ST.unsafeThaw and alias them to Data.Array.ST.Unsafe.unsafeFreeze and Data.Array.ST.Unsafe.unsafeThaw, so that they can be removed in a future release, for consistency with Foreign.Object.ST.Unsafe.unsafeFreeze (see https://github.com/purescript/purescript-arrays/issues/185).

The Data.Array.ST.Internal module is unfortunate but otherwise there’s a circular dependency between Data.Array.ST and Data.Array.ST.Unsafe. We could also move Foreign.Object.ST.Unsafe.unsafeFreeze into Foreign.Object.ST to avoid those changes while still being consistent.