### PR TITLE
Rename Data.Array.ST.empty

### DIFF
--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -887,10 +887,10 @@ group' = group <<< sort
 groupBy :: forall a. (a -> a -> Boolean) -> Array a -> Array (NonEmptyArray a)
 groupBy op xs =
   ST.run do
-    result <- STA.empty
+    result <- STA.new
     iter <- STAI.iterator (xs !! _)
     STAI.iterate iter \x -> void do
-      sub <- STA.empty
+      sub <- STA.new
       _ <- STA.push x sub
       STAI.pushWhile (op x) iter sub
       grp <- STA.unsafeFreeze sub
@@ -952,7 +952,7 @@ nubBy comp xs = case head indexedAndSorted of
 -- |
 nubByEq :: forall a. (a -> a -> Boolean) -> Array a -> Array a
 nubByEq eq xs = ST.run do
-  arr <- STA.empty
+  arr <- STA.new
   ST.foreach xs \x -> do
     e <- not <<< Exports.any (_ `eq` x) <$> (STA.unsafeFreeze arr)
     when e $ void $ STA.push x arr
@@ -1101,8 +1101,8 @@ zip = zipWith Tuple
 unzip :: forall a b. Array (Tuple a b) -> Tuple (Array a) (Array b)
 unzip xs =
   ST.run do
-    fsts <- STA.empty
-    snds <- STA.empty
+    fsts <- STA.new
+    snds <- STA.new
     iter <- STAI.iterator (xs !! _)
     STAI.iterate iter \(Tuple fst snd) -> do
       void $ STA.push fst fsts

--- a/src/Data/Array/ST.js
+++ b/src/Data/Array/ST.js
@@ -1,6 +1,6 @@
 "use strict";
 
-exports.empty = function () {
+exports["new"] = function () {
   return [];
 };
 

--- a/src/Data/Array/ST.purs
+++ b/src/Data/Array/ST.purs
@@ -7,7 +7,7 @@ module Data.Array.ST
   , Assoc
   , run
   , withArray
-  , empty
+  , new
   , peek
   , poke
   , modify
@@ -75,8 +75,8 @@ foreign import unsafeFreeze :: forall h a. STArray h a -> ST h (Array a)
 -- | array must not be used afterward.
 foreign import unsafeThaw :: forall h a. Array a -> ST h (STArray h a)
 
--- | Create an empty mutable array.
-foreign import empty :: forall h a. ST h (STArray h a)
+-- | Create a new, empty mutable array.
+foreign import new :: forall h a. ST h (STArray h a)
 
 -- | Create a mutable copy of an immutable array.
 foreign import thaw :: forall h a. Array a -> ST h (STArray h a)

--- a/src/Data/Array/ST.purs
+++ b/src/Data/Array/ST.purs
@@ -8,6 +8,7 @@ module Data.Array.ST
   , run
   , withArray
   , new
+  , empty
   , peek
   , poke
   , modify
@@ -33,6 +34,7 @@ import Prelude
 import Control.Monad.ST as ST
 import Control.Monad.ST (ST, Region)
 import Data.Maybe (Maybe(..))
+import Prim.TypeError (class Warn, Text)
 
 -- | A reference to a mutable array.
 -- |
@@ -77,6 +79,9 @@ foreign import unsafeThaw :: forall h a. Array a -> ST h (STArray h a)
 
 -- | Create a new, empty mutable array.
 foreign import new :: forall h a. ST h (STArray h a)
+
+empty :: forall h a. Warn (Text "'Data.Array.ST.empty' is deprecated, use 'Data.Array.ST.new' instead") => ST h (STArray h a)
+empty = new
 
 -- | Create a mutable copy of an immutable array.
 foreign import thaw :: forall h a. Array a -> ST h (STArray h a)

--- a/test/Test/Data/Array/ST.purs
+++ b/test/Test/Data/Array/ST.purs
@@ -17,7 +17,7 @@ testArrayST = do
   log "run should produce an immutable array by running a constructor operation"
 
   assert $ STA.run (do
-    arr <- STA.empty
+    arr <- STA.new
     void $ STA.push 1 arr
     void $ STA.push 2 arr
     pure arr) == [1, 2]
@@ -30,7 +30,7 @@ testArrayST = do
 
   log "empty should produce an empty array"
 
-  assert $ STA.run STA.empty == nil
+  assert $ STA.run STA.new == nil
 
   log "thaw should produce an STArray from a standard array"
 
@@ -62,13 +62,13 @@ testArrayST = do
   log "pop should return Nothing when given an empty array"
 
   assert $ isNothing $ ST.run (do
-    arr <- STA.empty
+    arr <- STA.new
     STA.pop arr)
 
   log "push should append a value to the end of the array"
 
   assert $ STA.run (do
-    arr <- STA.empty
+    arr <- STA.new
     void $ STA.push 1 arr
     void $ STA.push 2 arr
     pure arr) == [1, 2]
@@ -87,7 +87,7 @@ testArrayST = do
   log "pushAll should append multiple values to the end of the array"
 
   assert $ STA.run (do
-    arr <- STA.empty
+    arr <- STA.new
     void $ STA.pushAll [1, 2] arr
     pure arr) == [1, 2]
 
@@ -105,7 +105,7 @@ testArrayST = do
   log "peek should return Nothing when peeking a value outside the array bounds"
 
   assert $ isNothing $ ST.run (do
-    arr <- STA.empty
+    arr <- STA.new
     STA.peek 0 arr)
 
   assert $ isNothing $ ST.run (do
@@ -113,7 +113,7 @@ testArrayST = do
     STA.peek 1 arr)
 
   assert $ isNothing $ ST.run (do
-    arr <- STA.empty
+    arr <- STA.new
     STA.peek (-1) arr)
 
   log "peek should return the value at the specified index"
@@ -139,7 +139,7 @@ testArrayST = do
   log "poke should return false when attempting to modify a value outside the array bounds"
 
   assert $ not $ ST.run (do
-    arr <- STA.empty
+    arr <- STA.new
     STA.poke 0 10 arr)
 
   assert $ not $ ST.run (do
@@ -180,13 +180,13 @@ testArrayST = do
   log "shift should return Nothing when given an empty array"
 
   assert $ isNothing $ ST.run (do
-    arr <- STA.empty
+    arr <- STA.new
     STA.shift arr)
 
   log "unshift should append a value to the front of the array"
 
   assert $ STA.run (do
-    arr <- STA.empty
+    arr <- STA.new
     void $ STA.unshift 1 arr
     void $ STA.unshift 2 arr
     pure arr) == [2, 1]
@@ -205,7 +205,7 @@ testArrayST = do
   log "unshiftAll should append multiple values to the front of the array"
 
   assert $ STA.run (do
-    arr <- STA.empty
+    arr <- STA.new
     void $ STA.unshiftAll [1, 2] arr
     pure arr) == [1, 2]
 


### PR DESCRIPTION
This pull request deprecate Data.Array.ST.empty and alias it to Data.Array.ST.new, so that it can be removed in a future release, for consistency with Foreign.Object.ST.new (see https://github.com/purescript/purescript-arrays/issues/186).