### PR TITLE
Replace Data.Array.ST.empty by Data.Array.ST.new

### DIFF
--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -611,7 +611,7 @@ intersperse a arr = case length arr of
   len | len < 2 -> arr
       | otherwise -> STA.run do
           let unsafeGetElem idx = unsafePartial (unsafeIndex arr idx)
-          out <- STA.empty
+          out <- STA.new
           _ <- STA.push (unsafeGetElem 0) out
           ST.for 1 len \idx -> do
             _ <- STA.push a out


### PR DESCRIPTION
Data.Array.ST.empty was deprecated in https://github.com/purescript/purescript-arrays/pull/191.