### PR TITLE
Implement foldMap1 for arrays in JavaScript to fuse mapping and folding

### DIFF
--- a/src/Data/Array/NonEmpty/Internal.js
+++ b/src/Data/Array/NonEmpty/Internal.js
@@ -21,6 +21,19 @@ exports.foldl1Impl = function (f) {
   };
 };
 
+exports.foldMap1Impl = function (append) {
+  return function (f) {
+    return function (xs) {
+      var acc = f(xs[0]);
+      var len = xs.length;
+      for (var i = 1; i < len; i++) {
+        acc = append(acc)(f(xs[i]));
+      }
+      return acc;
+    };
+  };
+};
+
 exports.traverse1Impl = function () {
   function Cont(fn) {
     this.fn = fn;

--- a/src/Data/Array/NonEmpty/Internal.purs
+++ b/src/Data/Array/NonEmpty/Internal.purs
@@ -15,7 +15,7 @@ import Data.Foldable (class Foldable)
 import Data.FoldableWithIndex (class FoldableWithIndex)
 import Data.FunctorWithIndex (class FunctorWithIndex)
 import Data.Ord (class Ord1)
-import Data.Semigroup.Foldable (class Foldable1, foldMap1DefaultL)
+import Data.Semigroup.Foldable (class Foldable1)
 import Data.Semigroup.Traversable (class Traversable1, sequence1Default)
 import Data.Traversable (class Traversable)
 import Data.TraversableWithIndex (class TraversableWithIndex)
@@ -48,7 +48,7 @@ derive newtype instance foldableNonEmptyArray :: Foldable NonEmptyArray
 derive newtype instance foldableWithIndexNonEmptyArray :: FoldableWithIndex Int NonEmptyArray
 
 instance foldable1NonEmptyArray :: Foldable1 NonEmptyArray where
-  foldMap1 = foldMap1DefaultL
+  foldMap1 = foldMap1Impl (<>)
   foldr1 = foldr1Impl
   foldl1 = foldl1Impl
 
@@ -73,6 +73,8 @@ derive newtype instance altNonEmptyArray :: Alt NonEmptyArray
 -- we use FFI here to avoid the unncessary copy created by `tail`
 foreign import foldr1Impl :: forall a. (a -> a -> a) -> NonEmptyArray a -> a
 foreign import foldl1Impl :: forall a. (a -> a -> a) -> NonEmptyArray a -> a
+
+foreign import foldMap1Impl :: forall a m. (m -> m -> m) -> (a -> m) -> NonEmptyArray a -> m
 
 foreign import traverse1Impl
   :: forall m a b


### PR DESCRIPTION
The default implementations of foldMap1 have to map over the array before folding it, but we can avoid to traverse the array twice with a foreign implementation.