### PR TITLE
Make `union*`, `difference*`, and `intersect*` run linearly by sorting elements first

### DIFF
--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -1087,7 +1087,7 @@ union = unionBy compare
 -- | ```
 -- |
 unionBy :: forall a. (a -> a -> Ordering) -> Array a -> Array a -> Array a
-unionBy cmp left right = map snd $ sortWith fst $ ST.run do
+unionBy cmp left right = map snd $ ST.run do
   result <- STA.new
   ST.foreach indexedAndSorted \(Tuple fromLeftArray pair@(Tuple _ x')) -> do
     if fromLeftArray then do
@@ -1100,6 +1100,7 @@ unionBy cmp left right = map snd $ sortWith fst $ ST.run do
           | otherwise -> pure unit
         Nothing -> do
           void $ STA.push pair result
+  _ <- STA.sortWith fst result
   STA.unsafeFreeze result
   where
     -- Note: when elements are equal, left array elements
@@ -1155,7 +1156,7 @@ infix 5 difference as \\
 differenceBy :: forall a. (a -> a -> Ordering) -> Array a -> Array a -> Array a
 differenceBy   _ left       [] = left
 differenceBy   _ left@[]     _ = left
-differenceBy cmp left    right = map snd $ sortWith fst $ ST.run do
+differenceBy cmp left    right = map snd $ ST.run do
   result <- STA.new
   latestRightArrayValue <- STRef.new Nothing
   ST.foreach indexedAndSorted \(Tuple fromLeftArray pair@(Tuple _ x')) -> do
@@ -1177,6 +1178,7 @@ differenceBy cmp left    right = map snd $ sortWith fst $ ST.run do
         void $ STRef.write next latestRightArrayValue
       false, _ -> do
         void $ STRef.write (Just (Tuple x' 1)) latestRightArrayValue
+  _ <- STA.sortWith fst result
   STA.unsafeFreeze result
   where
     -- Note: when elements are equal, right array elements
@@ -1244,7 +1246,7 @@ intersect = intersectBy compare
 intersectBy :: forall a. (a -> a -> Ordering) -> Array a -> Array a -> Array a
 intersectBy _   left       [] = left
 intersectBy _   left@[]     _ = left
-intersectBy cmp left    right = map snd $ sortWith fst $ ST.run do
+intersectBy cmp left    right = map snd $ ST.run do
   result <- STA.new
   latestRightArrayValue <- STRef.new Nothing
   ST.foreach indexedAndSorted \(Tuple fromLeftArray pair@(Tuple i x')) ->
@@ -1256,6 +1258,7 @@ intersectBy cmp left    right = map snd $ sortWith fst $ ST.run do
         _ -> pure unit
     else do
       void $ STRef.write (Just x') latestRightArrayValue
+  _ <- STA.sortWith fst result
   STA.unsafeFreeze result
   where
     -- Note: when elements are equal, right array elements

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -1206,8 +1206,8 @@ differenceBy cmp left    right = map snd $ ST.run do
 -- ... but without creating two intermediate arrays due to the `mapWithIndex`
 -- on both arrays.
 -- ```
--- combineIndex compare [0] [0, 1]
---   == [t3 true 0 0, t3 false 1 0, t3 false 2 1]
+-- combineIndex compare [7] [9, 5]
+--   == [t3 true 0 7, t3 false 1 9, t3 false 2 5]
 -- ```
 combineIndex :: forall a. Array a -> Array a -> Array (Tuple Boolean (Tuple Int a))
 combineIndex left right = ST.run do

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -1195,9 +1195,10 @@ differenceBy cmp left    right = map snd $ ST.run do
 -- ```
 -- combineWithIndex cmp left right =
 -- let
---   leftIndexed = mapWithIndex (\idx v -> Tuple idx v) left
+--   t3 bool idx val = Tuple bool (Tuple idx val)
+--   leftIndexed = mapWithIndex (\idx v -> t3 true idx v) left
 --
---   tupleAdjusted idx v = Tuple (idx + (length left)) v
+--   tupleAdjusted idx v = t3 false (idx + (length left)) v
 --   rightIndexedPlus = mapWithIndex tupleAdjusted right
 --
 -- in leftIndexed <> rightIndexedPlus
@@ -1205,7 +1206,6 @@ differenceBy cmp left    right = map snd $ ST.run do
 -- ... but without creating two intermediate arrays due to the `mapWithIndex`
 -- on both arrays.
 -- ```
--- let t3 a b c = Tuple a (Tuple b c)
 -- combineIndex compare [0] [0, 1]
 --   == [t3 true 0 0, t3 false 1 0, t3 false 2 1]
 -- ```

--- a/src/Data/Array/NonEmpty.purs
+++ b/src/Data/Array/NonEmpty.purs
@@ -410,27 +410,27 @@ nubBy f = unsafeAdapt $ A.nubBy f
 nubByEq :: forall a. (a -> a -> Boolean) -> NonEmptyArray a -> NonEmptyArray a
 nubByEq f = unsafeAdapt $ A.nubByEq f
 
-union :: forall a. Eq a => NonEmptyArray a -> NonEmptyArray a -> NonEmptyArray a
-union = unionBy (==)
+union :: forall a. Ord a => NonEmptyArray a -> NonEmptyArray a -> NonEmptyArray a
+union = unionBy compare
 
-union' :: forall a. Eq a => NonEmptyArray a -> Array a -> NonEmptyArray a
-union' = unionBy' (==)
+union' :: forall a. Ord a => NonEmptyArray a -> Array a -> NonEmptyArray a
+union' = unionBy' compare
 
 unionBy
   :: forall a
-   . (a -> a -> Boolean)
+   . (a -> a -> Ordering)
   -> NonEmptyArray a
   -> NonEmptyArray a
   -> NonEmptyArray a
-unionBy eq xs = unionBy' eq xs <<< toArray
+unionBy cmp xs = unionBy' cmp xs <<< toArray
 
 unionBy'
   :: forall a
-   . (a -> a -> Boolean)
+   . (a -> a -> Ordering)
   -> NonEmptyArray a
   -> Array a
   -> NonEmptyArray a
-unionBy' eq xs = unsafeFromArray <<< A.unionBy eq (toArray xs)
+unionBy' cmp xs = unsafeFromArray <<< A.unionBy cmp (toArray xs)
 
 delete :: forall a. Eq a => a -> NonEmptyArray a -> Array a
 delete x = adaptAny $ A.delete x

--- a/src/Data/Array/NonEmpty.purs
+++ b/src/Data/Array/NonEmpty.purs
@@ -84,6 +84,8 @@ module Data.Array.NonEmpty
 
   , (\\), difference
   , difference'
+  , differenceBy
+  , differenceBy'
   , intersect
   , intersect'
   , intersectBy
@@ -436,21 +438,27 @@ delete x = adaptAny $ A.delete x
 deleteBy :: forall a. (a -> a -> Boolean) -> a -> NonEmptyArray a -> Array a
 deleteBy f x = adaptAny $ A.deleteBy f x
 
-difference :: forall a. Eq a => NonEmptyArray a -> NonEmptyArray a -> Array a
+difference :: forall a. Ord a => NonEmptyArray a -> NonEmptyArray a -> Array a
 difference xs = adaptAny $ difference' xs
 
-difference' :: forall a. Eq a => NonEmptyArray a -> Array a -> Array a
+difference' :: forall a. Ord a => NonEmptyArray a -> Array a -> Array a
 difference' xs = A.difference $ toArray xs
 
-intersect :: forall a . Eq a => NonEmptyArray a -> NonEmptyArray a -> Array a
-intersect = intersectBy eq
+differenceBy :: forall a. (a -> a -> Ordering) -> NonEmptyArray a -> NonEmptyArray a -> Array a
+differenceBy cmp xs = adaptAny $ differenceBy' cmp xs
 
-intersect' :: forall a . Eq a => NonEmptyArray a -> Array a -> Array a
-intersect' = intersectBy' eq
+differenceBy' :: forall a. (a -> a -> Ordering) -> NonEmptyArray a -> Array a -> Array a
+differenceBy' cmp xs = A.differenceBy cmp $ toArray xs
+
+intersect :: forall a . Ord a => NonEmptyArray a -> NonEmptyArray a -> Array a
+intersect = intersectBy compare
+
+intersect' :: forall a . Ord a => NonEmptyArray a -> Array a -> Array a
+intersect' = intersectBy' compare
 
 intersectBy
   :: forall a
-   . (a -> a -> Boolean)
+   . (a -> a -> Ordering)
   -> NonEmptyArray a
   -> NonEmptyArray a
   -> Array a
@@ -458,7 +466,7 @@ intersectBy eq xs = intersectBy' eq xs <<< toArray
 
 intersectBy'
   :: forall a
-   . (a -> a -> Boolean)
+   . (a -> a -> Ordering)
   -> NonEmptyArray a
   -> Array a
   -> Array a

--- a/test/Test/Data/Array.purs
+++ b/test/Test/Data/Array.purs
@@ -401,7 +401,8 @@ testArray = do
   assert $ A.union [1, 1, 2, 3] [2, 3, 4] == [1, 1, 2, 3, 4]
 
   log "unionBy should produce the union of two arrays using the specified equality relation"
-  assert $ A.unionBy (\_ y -> y < 5) [1, 2, 3] [2, 3, 4, 5, 6] == [1, 2, 3, 5, 6]
+  assert $ A.unionBy (\x y -> compare (x `mod` 4) (y `mod` 4))
+    [1, 2, 3] [2, 3, 4, 5, 6] == [1, 2, 3, 4]
 
   log "delete should remove the first matching item from an array"
   assert $ A.delete 1 [1, 2, 1] == [2, 1]

--- a/test/Test/Data/Array.purs
+++ b/test/Test/Data/Array.purs
@@ -413,12 +413,14 @@ testArray = do
 
   log "(\\\\) should return the difference between two lists"
   assert $ [1, 2, 3, 4, 3, 2, 1] \\ [1, 1, 2, 3] == [4, 3, 2]
+  assert $ [1, 2, 3, 4, 3, 2, 1] \\ [1, 1, 1, 1, 1, 2, 3] == [4, 3, 2]
+  assert $ [1, 4, 6, 8, 6, 4, 1] \\ [1, 4, 4, 1, 6] == [8, 6]
 
   log "intersect should return the intersection of two arrays"
   assert $ A.intersect [1, 2, 3, 4, 3, 2, 1] [1, 1, 2, 3] == [1, 2, 3, 3, 2, 1]
 
   log "intersectBy should return the intersection of two arrays using the specified equivalence relation"
-  assert $ A.intersectBy (\x y -> (x * 2) == y) [1, 2, 3] [2, 6] == [1, 3]
+  assert $ A.intersectBy (\x y -> compare (x `mod` 3) (y `mod` 3)) [1, 2, 3] [2, 6] == [2, 3]
 
   log "zipWith should use the specified function to zip two lists together"
   assert $ A.zipWith (\x y -> [show x, y]) [1, 2, 3] ["a", "b", "c"] == [["1", "a"], ["2", "b"], ["3", "c"]]

--- a/test/Test/Data/Array/NonEmpty.purs
+++ b/test/Test/Data/Array/NonEmpty.purs
@@ -295,7 +295,7 @@ testNonEmptyArray = do
   assert $ NEA.intersect (fromArray [1, 2, 3, 4, 3, 2, 1]) (fromArray [1, 1, 2, 3]) == [1, 2, 3, 3, 2, 1]
 
   log "intersectBy should return the intersection of two arrays using the specified equivalence relation"
-  assert $ NEA.intersectBy (\x y -> (x * 2) == y) (fromArray [1, 2, 3]) (fromArray [2, 6]) == [1, 3]
+  assert $ NEA.intersectBy (\x y -> compare (x `mod` 3) (y `mod` 3)) (fromArray [1, 2, 3]) (fromArray [2, 6]) == [2, 3]
 
   log "zipWith should use the specified function to zip two arrays together"
   assert $ NEA.zipWith (\x y -> [show x, y]) (fromArray [1, 2, 3]) (fromArray ["a", "b", "c"]) == fromArray [["1", "a"], ["2", "b"], ["3", "c"]]

--- a/test/Test/Data/Array/NonEmpty.purs
+++ b/test/Test/Data/Array/NonEmpty.purs
@@ -281,7 +281,8 @@ testNonEmptyArray = do
   assert $ NEA.union (fromArray [1, 1, 2, 3]) (fromArray [2, 3, 4]) == fromArray [1, 1, 2, 3, 4]
 
   log "unionBy should produce the union of two arrays using the specified equality relation"
-  assert $ NEA.unionBy (\_ y -> y < 5) (fromArray [1, 2, 3]) (fromArray [2, 3, 4, 5, 6]) == fromArray [1, 2, 3, 5, 6]
+  assert $ NEA.unionBy (\x y -> compare (x `mod` 4) (y `mod` 4))
+    (fromArray [1, 2, 3]) (fromArray [2, 3, 4, 5, 6]) == fromArray [1, 2, 3, 4]
 
   log "delete should remove the first matching item from an array"
   assert $ NEA.delete 1 (fromArray [1, 2, 1]) == [2, 1]


### PR DESCRIPTION
Fixes #192