### PR TITLE
Use Natural Transformations wherever possible

### DIFF
--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -628,7 +628,7 @@ intersperse a arr = case length arr of
 -- | reverse [1, 2, 3] = [3, 2, 1]
 -- | ```
 -- |
-foreign import reverse :: forall a. Array a -> Array a
+foreign import reverse :: Array ~> Array
 
 -- | Flatten an array of arrays, creating a new array.
 -- |

--- a/src/Data/Array/NonEmpty.purs
+++ b/src/Data/Array/NonEmpty.purs
@@ -162,31 +162,31 @@ fromArray xs
   | otherwise = Nothing
 
 -- | INTERNAL
-unsafeFromArray :: forall a. Array a -> NonEmptyArray a
+unsafeFromArray :: Array ~> NonEmptyArray
 unsafeFromArray = NonEmptyArray
 
 unsafeFromArrayF :: forall f a. f (Array a) -> f (NonEmptyArray a)
 unsafeFromArrayF = unsafeCoerce
 
-fromNonEmpty :: forall a. NonEmpty Array a -> NonEmptyArray a
+fromNonEmpty :: NonEmpty Array ~> NonEmptyArray
 fromNonEmpty (x :| xs) = cons' x xs
 
-toArray :: forall a. NonEmptyArray a -> Array a
+toArray :: NonEmptyArray ~> Array
 toArray (NonEmptyArray xs) = xs
 
-toNonEmpty :: forall a. NonEmptyArray a -> NonEmpty Array a
+toNonEmpty :: NonEmptyArray ~> NonEmpty Array
 toNonEmpty = uncons >>> \{head: x, tail: xs} -> x :| xs
 
 fromFoldable :: forall f a. Foldable f => f a -> Maybe (NonEmptyArray a)
 fromFoldable = fromArray <<< A.fromFoldable
 
-fromFoldable1 :: forall f a. Foldable1 f => f a -> NonEmptyArray a
+fromFoldable1 :: forall f. Foldable1 f => f ~> NonEmptyArray
 fromFoldable1 = unsafeFromArray <<< A.fromFoldable
 
-toUnfoldable :: forall f a. Unfoldable f => NonEmptyArray a -> f a
+toUnfoldable :: forall f. Unfoldable f => NonEmptyArray ~> f
 toUnfoldable = adaptAny A.toUnfoldable
 
-toUnfoldable1 :: forall f a. Unfoldable1 f => NonEmptyArray a -> f a
+toUnfoldable1 :: forall f. Unfoldable1 f => NonEmptyArray ~> f
 toUnfoldable1 xs = unfoldr1 f 0
   where
   len = length xs
@@ -244,10 +244,10 @@ head = adaptMaybe A.head
 last :: forall a. NonEmptyArray a -> a
 last = adaptMaybe A.last
 
-tail :: forall a. NonEmptyArray a -> Array a
+tail :: NonEmptyArray ~> Array
 tail = adaptMaybe A.tail
 
-init :: forall a. NonEmptyArray a -> Array a
+init :: NonEmptyArray ~> Array
 init = adaptMaybe A.init
 
 uncons :: forall a. NonEmptyArray a -> { head :: a, tail :: Array a }
@@ -309,7 +309,7 @@ alterAt i f = A.alterAt i f <<< toArray
 intersperse :: forall a. a -> NonEmptyArray a -> NonEmptyArray a
 intersperse x = unsafeAdapt $ A.intersperse x
 
-reverse :: forall a. NonEmptyArray a -> NonEmptyArray a
+reverse :: NonEmptyArray ~> NonEmptyArray
 reverse = unsafeAdapt A.reverse
 
 concat :: forall a. NonEmptyArray (NonEmptyArray a) -> NonEmptyArray a


### PR DESCRIPTION
This change makes the type signatures of `NonEmptyArray` functions more consistent with the other container types.

Here's an example of the previous inconsistencies:
https://pursuit.purescript.org/search?q=toUnfoldable