### PR TITLE
Fix minor documentation issue with find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Fixed minor documention issue with `find`
 
 ## [v6.0.1](https://github.com/purescript/purescript-arrays/releases/tag/v6.0.1) - 2021-04-19
 
@@ -26,7 +27,7 @@ Breaking changes:
 
 New features:
 - Added specialized versions of the functions from `Data.Foldable` (#201):
-  - Added `foldl`, `foldr`, `foldMap`, `fold`, `intercalate` to `Array` 
+  - Added `foldl`, `foldr`, `foldMap`, `fold`, `intercalate` to `Array`
   - Added `foldl1`, `foldr1`, `foldMap1`, `foldl1`, `intercalate` to `Array.NonEmpty`
 - Added specialized `elem`, `notElem`, `find`, `findMap`, `scanl`, `scanr`, `any`, `all` (#189, #193, #201)
 - Added `intersperse`, `groupAllBy`, `splitAt` (#179, #188, #194, #200, #201)
@@ -41,9 +42,9 @@ Other improvements:
 - Migrated to GitHub Actions for CI (#187, #169)
 - Removed some internal usages of `unsafeCoerce` (#184)
 - Changed `foldM` type signature to more closely match `foldl` (#160)
-- Updated installation instructions to use Spago (#171) 
+- Updated installation instructions to use Spago (#171)
 - Replaced foreign `cons`, `snoc`, `drop`, `take` with PureScript implementations (#180)
-- Removed `return {}` from FFI function for a small performance boost (#175) 
+- Removed `return {}` from FFI function for a small performance boost (#175)
 - Bumped pulp version (#174)
 - Removed primes from foreign modules exports (#168)
 
@@ -314,6 +315,3 @@ Added `mapMaybe`
 
 
 ## [v0.1.0](https://github.com/purescript/purescript-arrays/releases/tag/v0.1.0) - 2014-04-25
-
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
-- Fixed minor documention issue with `find`
+- Fixed minor documention issue with `find` (#216 by @JamieBallingall)
 
 ## [v6.0.1](https://github.com/purescript/purescript-arrays/releases/tag/v6.0.1) - 2021-04-19
 
@@ -311,7 +311,5 @@ Include `(..)` operator.
 Added `mapMaybe`
 
 ## [v0.1.1](https://github.com/purescript/purescript-arrays/releases/tag/v0.1.1) - 2014-04-27
-
-
 
 ## [v0.1.0](https://github.com/purescript/purescript-arrays/releases/tag/v0.1.0) - 2014-04-25

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -444,8 +444,8 @@ elemLastIndex x = findLastIndex (_ == x)
 -- | Find the first element for which a predicate holds.
 -- |
 -- | ```purescript
--- | findIndex (contains $ Pattern "b") ["a", "bb", "b", "d"] = Just "bb"
--- | findIndex (contains $ Pattern "x") ["a", "bb", "b", "d"] = Nothing
+-- | find (contains $ Pattern "b") ["a", "bb", "b", "d"] = Just "bb"
+-- | find (contains $ Pattern "x") ["a", "bb", "b", "d"] = Nothing
 -- | ```
 find :: forall a. (a -> Boolean) -> Array a -> Maybe a
 find f xs = unsafePartial (unsafeIndex xs) <$> findIndex f xs


### PR DESCRIPTION
The example for `find` showed `findIndex`. This PR fixes that.

---

**Checklist:**

- [X] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [NA] Linked any existing issues or proposals that this pull request should close
- [X] Updated or added relevant documentation
- [NA] Added a test for the contribution (if applicable)
