### PR TITLE
Add prependArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Add `prependArray` (#224 by @JordanMartinez)
 
 Bugfixes:
 

--- a/src/Data/Array/NonEmpty.purs
+++ b/src/Data/Array/NonEmpty.purs
@@ -21,6 +21,7 @@ module Data.Array.NonEmpty
   , snoc
   , snoc'
   , appendArray
+  , prependArray
   , insert
   , insertBy
 
@@ -229,6 +230,9 @@ snoc' xs x = unsafeFromArray $ A.snoc xs x
 
 appendArray :: forall a. NonEmptyArray a -> Array a -> NonEmptyArray a
 appendArray xs ys = unsafeFromArray $ toArray xs <> ys
+
+prependArray :: forall a. Array a -> NonEmptyArray a -> NonEmptyArray a
+prependArray xs ys = unsafeFromArray $ xs <> toArray ys
 
 insert :: forall a. Ord a => a -> NonEmptyArray a -> NonEmptyArray a
 insert x = unsafeAdapt $ A.insert x


### PR DESCRIPTION
**Description of the change**

`appendArray :: NonEmptyArray a -> Array a -> NonEmptyArray a` exists, but one cannot prepend. This adds that.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
