### PR TITLE
Build an array directly, not indirectly via list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Speed up `fromFoldable` by removing intermediate list construction (#231 by @JordanMartinez)
 
 ## [v7.1.0](https://github.com/purescript/purescript-arrays/releases/tag/v7.1.0) - 2022-08-06
 

--- a/src/Data/Array.js
+++ b/src/Data/Array.js
@@ -41,35 +41,19 @@ var replicatePolyfill = function (count) {
 export const replicate = typeof Array.prototype.fill === "function" ? replicateFill : replicatePolyfill;
 
 export const fromFoldableImpl = (function () {
-  function Cons(head, tail) {
-    this.head = head;
-    this.tail = tail;
-  }
-  var emptyList = {};
-
-  function curryCons(head) {
-    return function (tail) {
-      return new Cons(head, tail);
-    };
-  }
-
-  function listToArray(list) {
-    var result = [];
-    var count = 0;
-    var xs = list;
-    while (xs !== emptyList) {
-      result[count++] = xs.head;
-      xs = xs.tail;
+  function accumulate(acc) {
+    return function (next) {
+      acc.push(next);
+      return acc;
     }
-    return result;
   }
-
-  return function (foldr) {
+  return function(foldl) {
     return function (xs) {
-      return listToArray(foldr(curryCons)(emptyList)(xs));
+      return foldl(accumulate)([])(xs);
     };
-  };
+  }
 })();
+
 
 //------------------------------------------------------------------------------
 // Array size ------------------------------------------------------------------

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -166,11 +166,11 @@ toUnfoldable xs = unfoldr f 0
 -- | ```
 -- |
 fromFoldable :: forall f. Foldable f => f ~> Array
-fromFoldable = fromFoldableImpl F.foldr
+fromFoldable = fromFoldableImpl F.foldl
 
 foreign import fromFoldableImpl
   :: forall f a
-   . (forall b. (a -> b -> b) -> b -> f a -> b)
+   . (forall b. (b -> a -> b) -> b -> f a -> b)
   -> f a
   -> Array a
 


### PR DESCRIPTION
**Description of the change**

I noticed that `fromFoldable`'s FFI will create an intermediate list that it will then unfold into an array. AFAICT, this is completely pointless because we can just build the initial array and then reverse it.

Does anyone know why this was implemented this way?

In my implementation, I changed the `foldr` to `foldl` because if the `Foldable f` is a `List`, `foldr` will first reverse the list before passing it to this function. So, we actually traverse the list 3 times:
1. reversing the initial list
2. folding over the arg passed to `fromFoldable` when constructing the intermediate list
3. folding over the intermediate list to build the array

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
