### PR TITLE
Avoid unnecessary array allocation

### DIFF
--- a/src/Data/Array/ST.js
+++ b/src/Data/Array/ST.js
@@ -45,6 +45,14 @@ export const pushAll = function (as) {
   };
 };
 
+export const push = function (a) {
+  return function (xs) {
+    return function () {
+      return xs.push(a);
+    };
+  };
+};
+
 export const shiftImpl = function (just) {
   return function (nothing) {
     return function (xs) {

--- a/src/Data/Array/ST.purs
+++ b/src/Data/Array/ST.purs
@@ -60,8 +60,8 @@ run st = ST.run (st >>= unsafeFreeze)
 withArray
   :: forall h a b
    . (STArray h a -> ST h b)
-   -> Array a
-   -> ST h (Array a)
+  -> Array a
+  -> ST h (Array a)
 withArray f xs = do
   result <- thaw xs
   _ <- f result
@@ -162,8 +162,7 @@ foreign import popImpl
 
 -- | Append an element to the end of a mutable array. Returns the new length of
 -- | the array.
-push :: forall h a. a -> STArray h a -> ST h Int
-push a = pushAll [a]
+foreign import push :: forall h a. a -> STArray h a -> ST h Int
 
 -- | Append the values in an immutable array to the end of a mutable array.
 -- | Returns the new length of the mutable array.
@@ -176,7 +175,7 @@ foreign import pushAll
 -- | Append an element to the front of a mutable array. Returns the new length of
 -- | the array.
 unshift :: forall h a. a -> STArray h a -> ST h Int
-unshift a = unshiftAll [a]
+unshift a = unshiftAll [ a ]
 
 -- | Append the values in an immutable array to the front of a mutable array.
 -- | Returns the new length of the mutable array.
@@ -191,7 +190,7 @@ modify :: forall h a. Int -> (a -> a) -> STArray h a -> ST h Boolean
 modify i f xs = do
   entry <- peek i xs
   case entry of
-    Just x  -> poke i (f x) xs
+    Just x -> poke i (f x) xs
     Nothing -> pure false
 
 -- | Remove and/or insert elements from/into a mutable array at the specified index.


### PR DESCRIPTION
**Description of the change**

Avoids reusing `pushAll` to implement `push` which saves on array allocations.

Closes #236 

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
