### PR TITLE
Add length to Data.Array.ST

### DIFF
--- a/src/Data/Array/ST.js
+++ b/src/Data/Array/ST.js
@@ -27,6 +27,12 @@ export const poke = function (i) {
   };
 };
 
+export const lengthImpl = function (xs) {
+  return function () {
+    return xs.length;
+  };
+};
+
 export const popImpl = function (just) {
   return function (nothing) {
     return function (xs) {

--- a/src/Data/Array/ST.purs
+++ b/src/Data/Array/ST.purs
@@ -11,6 +11,7 @@ module Data.Array.ST
   , peek
   , poke
   , modify
+  , length
   , pop
   , push
   , pushAll
@@ -148,6 +149,12 @@ foreign import peekImpl
 
 -- | Change the value at the specified index in a mutable array.
 foreign import poke :: forall h a. Int -> a -> STArray h a -> ST h Boolean
+
+-- | Get the number of elements in a mutable array.
+length :: forall h a. STArray h a -> ST h Int
+length = lengthImpl
+
+foreign import lengthImpl :: forall h a. STArray h a -> ST h Int
 
 -- | Remove the last element from an array and return that element.
 pop :: forall h a. STArray h a -> ST h (Maybe a)

--- a/test/Test/Data/Array/ST.purs
+++ b/test/Test/Data/Array/ST.purs
@@ -49,6 +49,23 @@ testArrayST = do
 
   assert $ STA.run (STA.unsafeThaw [1, 2, 3]) == [1, 2, 3]
 
+  log "length should return the number of items in an STArray"
+
+  assert $ ST.run (do
+    arr <- STA.thaw nil
+    length <- STA.length arr
+    pure $ length == 0)
+
+  assert $ ST.run (do
+    arr <- STA.thaw [1]
+    length <- STA.length arr
+    pure $ length == 1)
+
+  assert $ ST.run (do
+    arr <- STA.thaw [1, 2, 3, 4, 5]
+    length <- STA.length arr
+    pure $ length == 5)
+
   log "pop should remove elements from an STArray"
 
   assert $ STA.run (do


### PR DESCRIPTION
**Description of the change**

This PR adds `length :: forall h a. STArray h a -> ST h Int` to the Data.Array.ST module.
This was recently requested in #238 and i need it as well.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [X] Linked any existing issues or proposals that this pull request should close
- [X] Updated or added relevant documentation
- [X] Added a test for the contribution (if applicable)
