### PR TITLE
Add foreign implementation for push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+ - Implements `ST.push` via a call to JavaScript's native `push` instead of `pushAll` (#236 by @i-am-the-slime)
 
 ## [v7.2.1](https://github.com/purescript/purescript-arrays/releases/tag/v7.2.1) - 2023-06-13
 

--- a/src/Data/Array/ST.js
+++ b/src/Data/Array/ST.js
@@ -106,10 +106,6 @@ export const toAssocArrayImpl = function (xs) {
   return as;
 };
 
-export const push = function (a) {
-   return function (xs) {
-     return function () {
-       return xs.push(a);
-     };
-   };
- };
+export const pushImpl = function (a, xs) {
+  return xs.push(a);
+};

--- a/src/Data/Array/ST.js
+++ b/src/Data/Array/ST.js
@@ -105,3 +105,11 @@ export const toAssocArrayImpl = function (xs) {
   for (var i = 0; i < n; i++) as[i] = { value: xs[i], index: i };
   return as;
 };
+
+export const push = function (a) {
+   return function (xs) {
+     return function () {
+       return xs.push(a);
+     };
+   };
+ };

--- a/src/Data/Array/ST.purs
+++ b/src/Data/Array/ST.purs
@@ -181,7 +181,10 @@ foreign import popImpl
 
 -- | Append an element to the end of a mutable array. Returns the new length of
 -- | the array.
-foreign import push :: forall h a. a -> STArray h a -> ST h Int
+push :: forall h a. a -> (STArray h a) -> ST h Int
+push = runSTFn2 pushImpl
+
+foreign import pushImpl :: forall h a. STFn2 a (STArray h a) h Int
 
 -- | Append the values in an immutable array to the end of a mutable array.
 -- | Returns the new length of the mutable array.

--- a/src/Data/Array/ST.purs
+++ b/src/Data/Array/ST.purs
@@ -181,8 +181,7 @@ foreign import popImpl
 
 -- | Append an element to the end of a mutable array. Returns the new length of
 -- | the array.
-push :: forall h a. a -> STArray h a -> ST h Int
-push a = runSTFn2 pushAllImpl [ a ]
+foreign import push :: forall h a. a -> STArray h a -> ST h Int
 
 -- | Append the values in an immutable array to the end of a mutable array.
 -- | Returns the new length of the mutable array.


### PR DESCRIPTION
**Avoid array allocation for push**

The previous implementation would create a new array every time
This one is a pretty faithful call into JS's `push`.

Supersedes #237 and closes #236 
---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
