### PR TITLE
Add clone to Data.Array.ST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Add `ST.clone` (#243 by @Bgbagan)
 
 Bugfixes:
 

--- a/src/Data/Array/ST.js
+++ b/src/Data/Array/ST.js
@@ -45,13 +45,15 @@ export const unsafeFreezeImpl = unsafeFreezeThawImpl;
 
 export const unsafeThawImpl = unsafeFreezeThawImpl;
 
-export function copyImpl(xs) {
+function copyImpl(xs) {
   return xs.slice();
 }
 
 export const freezeImpl = copyImpl;
 
 export const thawImpl = copyImpl;
+
+export const cloneImpl = copyImpl;
 
 export const sortByImpl = (function () {
   function mergeFromTo(compare, fromOrdering, xs1, xs2, from, to) {

--- a/src/Data/Array/ST.js
+++ b/src/Data/Array/ST.js
@@ -45,7 +45,7 @@ export const unsafeFreezeImpl = unsafeFreezeThawImpl;
 
 export const unsafeThawImpl = unsafeFreezeThawImpl;
 
-function copyImpl(xs) {
+export function copyImpl(xs) {
   return xs.slice();
 }
 

--- a/src/Data/Array/ST.purs
+++ b/src/Data/Array/ST.purs
@@ -24,7 +24,7 @@ module Data.Array.ST
   , sortWith
   , freeze
   , thaw
-  , copy
+  , clone
   , unsafeFreeze
   , unsafeThaw
   , toAssocArray
@@ -96,19 +96,17 @@ thaw = runSTFn1 thawImpl
 -- | Create a mutable copy of an immutable array.
 foreign import thawImpl :: forall h a. STFn1 (Array a) h (STArray h a)
 
--- | Sort a mutable array in place. Sorting is stable: the order of equal
--- | elements is preserved.
-
-
 -- | Make a mutable copy of a mutable array.
-copy
+clone
   :: forall h a
    . STArray h a
   -> ST h (STArray h a)
-copy = runSTFn1 copyImpl
+clone = runSTFn1 cloneImpl
 
-foreign import copyImpl :: forall h a. STFn1 (STArray h a) h (STArray h a)
+foreign import cloneImpl :: forall h a. STFn1 (STArray h a) h (STArray h a)
 
+-- | Sort a mutable array in place. Sorting is stable: the order of equal
+-- | elements is preserved.
 sort :: forall a h. Ord a => STArray h a -> ST h (STArray h a)
 sort = sortBy compare
 

--- a/src/Data/Array/ST.purs
+++ b/src/Data/Array/ST.purs
@@ -24,6 +24,7 @@ module Data.Array.ST
   , sortWith
   , freeze
   , thaw
+  , copy
   , unsafeFreeze
   , unsafeThaw
   , toAssocArray
@@ -97,6 +98,17 @@ foreign import thawImpl :: forall h a. STFn1 (Array a) h (STArray h a)
 
 -- | Sort a mutable array in place. Sorting is stable: the order of equal
 -- | elements is preserved.
+
+
+-- | Make a mutable copy of a mutable array.
+copy
+  :: forall h a
+   . STArray h a
+  -> ST h (STArray h a)
+copy = runSTFn1 copyImpl
+
+foreign import copyImpl :: forall h a. STFn1 (STArray h a) h (STArray h a)
+
 sort :: forall a h. Ord a => STArray h a -> ST h (STArray h a)
 sort = sortBy compare
 

--- a/test/Test/Data/Array/ST.purs
+++ b/test/Test/Data/Array/ST.purs
@@ -50,6 +50,7 @@ testArrayST = do
   assert $ ST.run (do
     arr <- STA.thaw [1, 2, 3]
     arr2 <- STA.clone arr
+    _ <- STA.poke 0 4 arr
     STA.freeze arr2) == [1, 2, 3]
 
   log "unsafeThaw should produce an STArray from a standard array"

--- a/test/Test/Data/Array/ST.purs
+++ b/test/Test/Data/Array/ST.purs
@@ -45,6 +45,13 @@ testArrayST = do
     arr <- STA.thaw [1, 2, 3]
     STA.freeze arr) == [1, 2, 3]
 
+  log "copy should produce a shallow copy of an STArray"
+
+  assert $ ST.run (do
+    arr <- STA.thaw [1, 2, 3]
+    arr2 <- STA.copy arr
+    STA.freeze arr2) == [1, 2, 3]
+
   log "unsafeThaw should produce an STArray from a standard array"
 
   assert $ STA.run (STA.unsafeThaw [1, 2, 3]) == [1, 2, 3]

--- a/test/Test/Data/Array/ST.purs
+++ b/test/Test/Data/Array/ST.purs
@@ -45,11 +45,11 @@ testArrayST = do
     arr <- STA.thaw [1, 2, 3]
     STA.freeze arr) == [1, 2, 3]
 
-  log "copy should produce a shallow copy of an STArray"
+  log "clone should produce a shallow copy of an STArray"
 
   assert $ ST.run (do
     arr <- STA.thaw [1, 2, 3]
-    arr2 <- STA.copy arr
+    arr2 <- STA.clone arr
     STA.freeze arr2) == [1, 2, 3]
 
   log "unsafeThaw should produce an STArray from a standard array"


### PR DESCRIPTION
**Description of the change**

This PR adds `clone :: forall h a. STArray h a -> ST h (STArray h a)` to the Data.Array.ST module.
It makes a mutable copy of a mutable array.
This is similar to the `clone` function in the Haskell module `Data.Vector.Mutable`.
This is equivalent to `unsafeThaw <<< freeze` but more readable.
I need it in one of my projects.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [X] Updated or added relevant documentation
- [X] Added a test for the contribution (if applicable)

