### PR TITLE
generalizes `deleteBy` parameter type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Generalizes the parameter type of `deleteBy` (#245 by @acple)
 
 ## [v7.3.0](https://github.com/purescript/purescript-arrays/releases/tag/v7.3.0) - 2023-11-03
 

--- a/src/Data/Array.purs
+++ b/src/Data/Array.purs
@@ -1190,7 +1190,7 @@ delete = deleteBy eq
 -- | deleteBy mod3eq 6 [1, 3, 4, 3] = [1, 4, 3]
 -- | ```
 -- |
-deleteBy :: forall a. (a -> a -> Boolean) -> a -> Array a -> Array a
+deleteBy :: forall a b. (b -> a -> Boolean) -> b -> Array a -> Array a
 deleteBy _ _ [] = []
 deleteBy eq x ys = maybe ys (\i -> unsafePartial $ fromJust (deleteAt i ys)) (findIndex (eq x) ys)
 


### PR DESCRIPTION
This generalizes `deleteBy` parameter without any implementation changes.

Current problem is that we must have actual value or a dummy of the type of array item while using `deleteBy`:

```purescript
type Id = Int
type ComplicatedRecord = { id :: Id, a :: String, b :: Boolean, c :: ... }

deleteById :: Id -> Array ComplicatedRecord -> Array ComplicatedRecord
deleteById id = ? -- cannot implement with `deleteBy` unless creating dummy value of ComplicatedRecord
```

This PR allows it like this:

```purescript
deleteById :: Id -> Array ComplicatedRecord -> Array ComplicatedRecord
deleteById = deleteBy \id item -> id == item.id
```

I believe this PR is almost non-breaking, however, there is a slight possibility of breakage related to type inference things.
I verified that the all of latest package-set items can be built with this change.

---

Alternative approach:

```purescript
delete :: forall a. Eq a => a -> Array a -> Array a
delete x = deleteBy (eq x)

deleteBy :: forall a. (a -> Boolean) -> Array a -> Array a
deleteBy p xs = _

-- usage
deleteById :: Id -> Array _ -> Array _
deleteById id = deleteBy \item -> id == item.id
```

This has more clear signature similar to `filter` and easy to understand but is a Breaking-change.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
